### PR TITLE
barebones end-to-end example

### DIFF
--- a/fritz
+++ b/fritz
@@ -14,6 +14,7 @@ def run(args):
     env.update({"FLAGS": "--config=../fritz.yaml"})
 
     if args.init:
+        # todo: config.yaml.defaults to config.yaml if config.yaml does not exist
         # subprocess.run(["make", "db_init"], cwd="skyportal", env=env)
         subprocess.run(["make", "docker-local"], cwd="skyportal", env=env)
         #source /skyportal_env/bin/activate

--- a/fritz
+++ b/fritz
@@ -16,11 +16,15 @@ def run(args):
     if args.init:
         # subprocess.run(["make", "db_init"], cwd="skyportal", env=env)
         subprocess.run(["make", "docker-local"], cwd="skyportal", env=env)
+        #source /skyportal_env/bin/activate
         subprocess.run(["docker-compose", "build"], cwd="kowalski")
     else:
         # start up skyportal
         # subprocess.run(["make", "run"], cwd="skyportal", env=env)
         subprocess.run(["docker-compose", "up", "-d"], cwd="skyportal", env=env)
+        # init skyportal and load test data
+        subprocess.run(["docker", "exec", "-it", "skyportal_web_1", "/bin/bash", "-c",
+                        "'source /skyportal_env/bin/activate; make load_demo_data'"], cwd="skyportal", env=env)
         # start up kowalski
         subprocess.run(["docker-compose", "up", "-d"], cwd="kowalski")
 

--- a/fritz
+++ b/fritz
@@ -24,7 +24,7 @@ def run(args):
         subprocess.run(["docker-compose", "up", "-d"], cwd="skyportal", env=env)
         # init skyportal and load test data
         subprocess.run(["docker", "exec", "-it", "skyportal_web_1", "/bin/bash", "-c",
-                        "'source /skyportal_env/bin/activate; make load_demo_data'"], cwd="skyportal", env=env)
+                        "source /skyportal_env/bin/activate; make load_demo_data"], cwd="skyportal", env=env)
         # start up kowalski
         subprocess.run(["docker-compose", "up", "-d"], cwd="kowalski")
 


### PR DESCRIPTION
I got it working with the dockerized version of SkyPortal! However, several things need to be addressed:

- See [this SkyPortal issue](https://github.com/skyportal/skyportal/issues/377)
- See [this SkyPortal issue](https://github.com/skyportal/skyportal/issues/378)
- need to put in a db password into the config file(s). 

With these fixes, running
```bash
./fritz run --init
./fritz run
docker exec -it kowalski_ingester_1 python -m pytest -s test_ingester.py
```
should execute a barebones end-to-end example.
