### PR TITLE
Add `data` folder to built docs

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -18,3 +18,8 @@ help:
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+html:
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	cp -r data _build/html
+	touch _build/html/.nojekyll

--- a/fritz
+++ b/fritz
@@ -257,7 +257,6 @@ def test(args):
 
 def doc(args):
     subprocess.run(["make", "html"], cwd="doc", check=True)
-    Path("doc/_build/html/.nojekyll").touch()
 
     if args.upload:
         subprocess.run(


### PR DESCRIPTION
These `.json` files are not currently copied to the output directory.
This seems to be a problem with the way recommonmark handles links with
extensions.

See also https://github.com/readthedocs/recommonmark/issues/130#issuecomment-658632877