### PR TITLE
Save ZTF alerts as sources by objectId

### DIFF
--- a/doc/user_guide.md
+++ b/doc/user_guide.md
@@ -2161,7 +2161,7 @@ Initialize `fritz` and run tests:
 ./fritz test
 ```
 
-Go to `http://localhost:9000/` -- you should see a few real alerts that passed a test filter among the displayed sources.
+Go to `http://localhost:5000/` -- you should see a few real alerts that passed a test filter among the displayed sources.
 
 To shut down `fritz`, run:
 

--- a/extensions/skyportal/skyportal/handlers/api/alert.py
+++ b/extensions/skyportal/skyportal/handlers/api/alert.py
@@ -401,6 +401,12 @@ class ZTFAlertHandler(BaseHandler):
                 return self.error(
                     "You must belong to one or more groups before you can add sources."
                 )
+            if (group_ids is not None) and (len(set(group_ids) - set(user_accessible_group_ids)) > 0):
+                forbidden_groups = list(set(group_ids) - set(user_accessible_group_ids))
+                return self.error(
+                    "Insufficient group access permissions. Not a member of "
+                    f"group IDs: {forbidden_groups}."
+                )
             try:
                 group_ids = [
                     int(_id)

--- a/extensions/skyportal/skyportal/handlers/api/alert.py
+++ b/extensions/skyportal/skyportal/handlers/api/alert.py
@@ -221,13 +221,13 @@ class ZTFAlertHandler(BaseHandler):
                     properties:
                       candid:
                         type: integer
-                        description: "[fritz] science program filter id for this user group id"
+                        description: "alert candid to use to pull thumbnails. defaults to latest alert"
                         minimum: 1
                       group_ids:
                         type: array
                         items:
                           type: integer
-                        description: "group ids to save source to"
+                        description: "group ids to save source to. defaults to all user groups"
                         minItems: 1
         responses:
           200:

--- a/extensions/skyportal/skyportal/handlers/api/alert.py
+++ b/extensions/skyportal/skyportal/handlers/api/alert.py
@@ -446,7 +446,7 @@ class ZTFAlertHandler(BaseHandler):
                         group_stream_selector.update(set(stream.altdata.get("selector", [])))
 
                 if not set(selector).issubset(group_stream_selector):
-                    return self.error(f"Cannot save to group {group.name}: " 
+                    return self.error(f"Cannot save to group {group.name}: "
                                       "insufficient group alert stream permissions")
 
             DBSession().add(obj)

--- a/extensions/skyportal/skyportal/handlers/api/alert.py
+++ b/extensions/skyportal/skyportal/handlers/api/alert.py
@@ -459,7 +459,6 @@ class ZTFAlertHandler(BaseHandler):
             self.clear()
 
             # post cutouts
-            thumbnail_handler = ThumbnailHandler(request=self.request, application=self.application)
             for ttype, ztftype in [('new', 'Science'), ('ref', 'Template'), ('sub', 'Difference')]:
                 query = {
                     "query_type": "find",
@@ -492,15 +491,17 @@ class ZTFAlertHandler(BaseHandler):
                 thumb = make_thumbnail(cutout, ttype, ztftype)
 
                 try:
+                    thumbnail_handler = ThumbnailHandler(request=self.request, application=self.application)
                     thumbnail_handler.request.body = tornado.escape.json_encode(thumb)
                     thumbnail_handler.post()
-                except Exception:
+                except Exception as e:
                     log(f"Failed to post thumbnails of {objectId} | {candid}")
+                    log(str(e))
                 self.clear()
 
             self.push_all(action="skyportal/FETCH_SOURCES")
             self.push_all(action="skyportal/FETCH_RECENT_SOURCES")
-            return self.success(data={"id": obj.id})
+            return self.success(data={"id": objectId})
 
         except Exception:
             _err = traceback.format_exc()

--- a/extensions/skyportal/skyportal/handlers/api/alert.py
+++ b/extensions/skyportal/skyportal/handlers/api/alert.py
@@ -308,6 +308,8 @@ class ZTFAlertHandler(BaseHandler):
                 alert_data = tornado.escape.json_decode(resp.body).get('data', list(dict()))
                 if len(alert_data) > 0:
                     alert_data = alert_data[0]
+                else:
+                    return self.error(f"{objectId} not found on Kowalski")
             else:
                 return self.error(f"Failed to fetch data for {objectId} from Kowalski")
 

--- a/extensions/skyportal/skyportal/handlers/api/alert.py
+++ b/extensions/skyportal/skyportal/handlers/api/alert.py
@@ -40,7 +40,7 @@ def make_thumbnail(a, ttype, ztftype):
     cutout_data = a[f'cutout{ztftype}']['stampData']
     with gzip.open(io.BytesIO(cutout_data), 'rb') as f:
         with fits.open(io.BytesIO(f.read())) as hdu:
-            header = hdu[0].header
+            # header = hdu[0].header
             data_flipped_y = np.flipud(hdu[0].data)
     # fixme: png, switch to fits eventually
     buff = io.BytesIO()
@@ -403,7 +403,7 @@ class ZTFAlertHandler(BaseHandler):
                     for _id in group_ids
                     if int(_id) in user_accessible_group_ids
                 ]
-            except:
+            except Exception:
                 group_ids = user_group_ids
             if not group_ids:
                 return self.error(
@@ -451,7 +451,7 @@ class ZTFAlertHandler(BaseHandler):
             photometry_handler.request.body = tornado.escape.json_encode(photometry)
             try:
                 photometry_handler.post()
-            except:
+            except Exception:
                 log(f"Failed to post photometry of {objectId}")
             # do not return anything yet
             self.clear()
@@ -492,7 +492,7 @@ class ZTFAlertHandler(BaseHandler):
                 try:
                     thumbnail_handler.request.body = tornado.escape.json_encode(thumb)
                     thumbnail_handler.post()
-                except:
+                except Exception:
                     log(f"Failed to post thumbnails of {objectId} | {candid}")
                 self.clear()
 

--- a/extensions/skyportal/skyportal/handlers/api/alert.py
+++ b/extensions/skyportal/skyportal/handlers/api/alert.py
@@ -499,6 +499,9 @@ class ZTFAlertHandler(BaseHandler):
                     log(str(e))
                 self.clear()
 
+            # todo: notify Kowalski so that it puts this objectId on tracking list
+            #  (to post new photometry to SP when new alerts arrive)
+
             self.push_all(action="skyportal/FETCH_SOURCES")
             self.push_all(action="skyportal/FETCH_RECENT_SOURCES")
             return self.success(data={"id": objectId})

--- a/extensions/skyportal/skyportal/handlers/api/alert.py
+++ b/extensions/skyportal/skyportal/handlers/api/alert.py
@@ -106,11 +106,15 @@ class ZTFAlertHandler(BaseHandler):
                                 "candidate.jd": 1,
                                 "candidate.programid": 1,
                                 "candidate.fid": 1,
+                                "candidate.ra": 1,
+                                "candidate.dec": 1,
                                 "candidate.magpsf": 1,
                                 "candidate.sigmapsf": 1,
                                 "candidate.rb": 1,
                                 "candidate.drb": 1,
                                 "candidate.isdiffpos": 1,
+                                "coordinates.l": 1,
+                                "coordinates.b": 1,
                             }
                         },
                     ]
@@ -225,6 +229,8 @@ class ZTFAlertAuxHandler(ZTFAlertHandler):
                                 "prv_candidates.diffmaglim": 1,
                                 "prv_candidates.programid": 1,
                                 "prv_candidates.fid": 1,
+                                "prv_candidates.ra": 1,
+                                "prv_candidates.dec": 1,
                                 "prv_candidates.candid": 1,
                                 "prv_candidates.jd": 1,
                             }
@@ -271,9 +277,13 @@ class ZTFAlertAuxHandler(ZTFAlertHandler):
                                 "candidate.programid": 1,
                                 "candidate.jd": 1,
                                 "candidate.fid": 1,
+                                "candidate.ra": 1,
+                                "candidate.dec": 1,
                                 "candidate.magpsf": 1,
                                 "candidate.sigmapsf": 1,
                                 "candidate.diffmaglim": 1,
+                                "coordinates.l": 1,
+                                "coordinates.b": 1,
                             }
                         },
                         {

--- a/extensions/skyportal/skyportal/handlers/api/alert.py
+++ b/extensions/skyportal/skyportal/handlers/api/alert.py
@@ -2,21 +2,32 @@ from astropy.io import fits
 import bson.json_util as bj
 import gzip
 import io
+from marshmallow.exceptions import ValidationError
 import matplotlib.colors as mplc
 import matplotlib.pyplot as plt
 import numpy as np
 import os
+import pandas as pd
 import pathlib
 import requests
 import traceback
 
 from baselayer.app.access import auth_or_token
+from baselayer.log import make_log
 from ..base import BaseHandler
 from ...models import (
     DBSession,
+    Group,
+    Obj,
     Stream,
     StreamUser,
+    Source,
 )
+from .photometry import PhotometryHandler
+from .source import SourceHandler
+
+
+log = make_log("alert")
 
 
 s = requests.Session()
@@ -29,13 +40,27 @@ class ZTFAlertHandler(BaseHandler):
             DBSession()
             .query(Stream)
             .join(StreamUser)
-            .filter(StreamUser.user_id == self.current_user.id)
+            .filter(StreamUser.user_id == self.associated_user_object.id)
             .all()
         )
         if streams is None:
             streams = []
 
         return streams
+
+    def query_kowalski(self, query, timeout=7):
+        base_url = f"{self.cfg['app.kowalski.protocol']}://" \
+                   f"{self.cfg['app.kowalski.host']}:{self.cfg['app.kowalski.port']}"
+        headers = {"Authorization": f"Bearer {self.cfg['app.kowalski.token']}"}
+
+        resp = s.post(
+            os.path.join(base_url, 'api/queries'),
+            json=query,
+            headers=headers,
+            timeout=timeout
+        )
+
+        return resp
 
     @auth_or_token
     def get(self, objectId: str = None):
@@ -124,22 +149,254 @@ class ZTFAlertHandler(BaseHandler):
                 # }
             }
 
-            base_url = f"{self.cfg['app.kowalski.protocol']}://" \
-                       f"{self.cfg['app.kowalski.host']}:{self.cfg['app.kowalski.port']}"
-            headers = {"Authorization": f"Bearer {self.cfg['app.kowalski.token']}"}
+            candid = self.get_query_argument('candid', None)
+            if candid:
+                query["query"]["pipeline"][0]["$match"]["candid"] = int(candid)
 
-            resp = s.post(
-                os.path.join(base_url, 'api/queries'),
-                json=query,
-                headers=headers,
-                timeout=7
-            )
+            resp = self.query_kowalski(query=query)
 
             if resp.status_code == requests.codes.ok:
                 alert_data = bj.loads(resp.text).get('data')
                 return self.success(data=alert_data)
             else:
                 return self.error(f"Failed to fetch data for {objectId} from Kowalski")
+
+        except Exception:
+            _err = traceback.format_exc()
+            return self.error(f'failure: {_err}')
+
+    @auth_or_token
+    def post(self, objectId):
+        """
+        ---
+        description: Save ZTF objectId from Kowalski as source in SkyPortal
+        requestBody:
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - type: object
+                    properties:
+                      candid:
+                        type: integer
+                        description: "[fritz] science program filter id for this user group id"
+                        minimum: 1
+                      group_ids:
+                        type: array
+                        items:
+                          type: integer
+                        description: "group ids to save source to"
+                        minItems: 1
+        responses:
+          200:
+            content:
+              application/json:
+                schema: Success
+          400:
+            content:
+              application/json:
+                schema: Error
+        """
+        streams = self.get_user_streams()
+
+        # allow access to public data only by default
+        selector = {1}
+
+        for stream in streams:
+            if "ztf" in stream.name.lower():
+                selector.update(set(stream.altdata.get("selector", [])))
+
+        selector = list(selector)
+
+        data = self.get_json()
+        candid = data.get("candid", None)
+        group_ids = data.pop("group_ids")
+
+        try:
+            query = {
+                "query_type": "aggregate",
+                "query": {
+                    "catalog": "ZTF_alerts_aux",
+                    "pipeline": [
+                        {
+                            "$match": {
+                                "_id": objectId
+                            }
+                        },
+                        {
+                            "$project": {
+                                "_id": 1,
+                                "cross_matches": 1,
+                                "prv_candidates": {
+                                    "$filter": {
+                                        "input": "$prv_candidates",
+                                        "as": "item",
+                                        "cond": {
+                                            "$in": [
+                                                "$$item.programid",
+                                                selector
+                                            ]
+                                        }
+                                    }
+                                },
+                            }
+                        },
+                        {
+                            "$project": {
+                                "_id": 1,
+                                "prv_candidates.magpsf": 1,
+                                "prv_candidates.sigmapsf": 1,
+                                "prv_candidates.diffmaglim": 1,
+                                "prv_candidates.programid": 1,
+                                "prv_candidates.fid": 1,
+                                "prv_candidates.rb": 1,
+                                "prv_candidates.ra": 1,
+                                "prv_candidates.dec": 1,
+                                "prv_candidates.candid": 1,
+                                "prv_candidates.jd": 1,
+                            }
+                        }
+                    ]
+                }
+            }
+
+            resp = self.query_kowalski(query=query)
+
+            if resp.status_code == requests.codes.ok:
+                alert_data = bj.loads(resp.text).get('data', list(dict()))
+                if len(alert_data) > 0:
+                    alert_data = alert_data[0]
+            else:
+                return self.error(f"Failed to fetch data for {objectId} from Kowalski")
+
+            # grab and append most recent candid as it should not be in prv_candidates
+            query = {
+                "query_type": "aggregate",
+                "query": {
+                    "catalog": "ZTF_alerts",
+                    "pipeline": [
+                        {
+                            "$match": {
+                                "objectId": objectId,
+                                "candidate.programid": {"$in": selector}
+                            }
+                        },
+                        {
+                            "$project": {
+                                # grab only what's going to be rendered
+                                "_id": 0,
+                                "candidate.candid": 1,
+                                "candidate.programid": 1,
+                                "candidate.jd": 1,
+                                "candidate.fid": 1,
+                                "candidate.rb": 1,
+                                "candidate.drb": 1,
+                                "candidate.ra": 1,
+                                "candidate.dec": 1,
+                                "candidate.magpsf": 1,
+                                "candidate.sigmapsf": 1,
+                                "candidate.diffmaglim": 1,
+                            }
+                        },
+                        {
+                            "$sort": {
+                                "candidate.jd": -1
+                            }
+                        },
+                        {
+                            "$limit": 1
+                        }
+                    ]
+                }
+            }
+
+            resp = self.query_kowalski(query=query)
+
+            if resp.status_code == requests.codes.ok:
+                latest_alert_data = bj.loads(resp.text).get('data', list(dict()))
+                if len(latest_alert_data) > 0:
+                    latest_alert_data = latest_alert_data[0]
+            else:
+                return self.error(f"Failed to fetch data for {objectId} from Kowalski")
+
+            if len(latest_alert_data) > 0:
+                candids = {a.get('candid', None) for a in alert_data['prv_candidates']}
+                if latest_alert_data['candidate']["candid"] not in candids:
+                    alert_data['prv_candidates'].append(latest_alert_data['candidate'])
+
+            # return self.success(data=alert_data)
+
+            df = pd.DataFrame.from_records(alert_data["prv_candidates"])
+            w = df["candid"] == candid
+
+            if candid is None or sum(w) == 0:
+                candid = int(df["candid"].max())
+                alert = df.loc[df["candid"] == candid].to_dict(orient="records")
+            else:
+                alert = df.loc[w].to_dict(orient="records")
+
+            # post source
+            obj = {
+                "id": objectId,
+                "ra": alert.get('ra'),
+                "dec": alert.get('dec'),
+                "score": alert.get('drb', alert['rb']),
+                "altdata": {
+                    "passing_alert_id": candid,
+                },
+                "group_ids": group_ids
+            }
+
+            source_handler = SourceHandler(request=self.request, application=self.application)
+            try:
+                source_handler.post(json=obj)
+                print(self.get_status())
+            except:
+                log(f"Failed to post {objectId}")
+            self.clear()
+
+            user_group_ids = [g.id for g in self.associated_user_object.groups]
+            user_accessible_group_ids = [g.id for g in self.associated_user_object.accessible_groups]
+            if not user_group_ids:
+                return self.error(
+                    "You must belong to one or more groups before you can add sources."
+                )
+            try:
+                group_ids = [
+                    int(_id)
+                    for _id in group_ids
+                    if int(_id) in user_accessible_group_ids
+                ]
+            except KeyError:
+                group_ids = user_group_ids
+            if not group_ids:
+                return self.error(
+                    "Invalid group_ids field. Please specify at least "
+                    "one valid group ID that you belong to."
+                )
+
+            groups = Group.query.filter(Group.id.in_(group_ids)).all()
+            if not groups:
+                return self.error(
+                    "Invalid group_ids field. Please specify at least "
+                    "one valid group ID that you belong to."
+                )
+            DBSession().add(obj)
+            DBSession().add_all([Source(obj=obj, group=group) for group in groups])
+            DBSession().commit()
+
+            # todo
+            photometry_handler = PhotometryHandler(request=self.request, application=self.application)
+            try:
+                photometry_handler.get(objectId)
+                print(self.get_status())
+            except:
+                log(f"Failed to post photometry of {objectId}")
+            self.clear()
+
+            self.push_all(action="skyportal/FETCH_SOURCES")
+            self.push_all(action="skyportal/FETCH_RECENT_SOURCES")
+            return self.success(data={"id": obj["id"]})
 
         except Exception:
             _err = traceback.format_exc()
@@ -239,16 +496,7 @@ class ZTFAlertAuxHandler(ZTFAlertHandler):
                 }
             }
 
-            base_url = f"{self.cfg['app.kowalski.protocol']}://" \
-                       f"{self.cfg['app.kowalski.host']}:{self.cfg['app.kowalski.port']}"
-            headers = {"Authorization": f"Bearer {self.cfg['app.kowalski.token']}"}
-
-            resp = s.post(
-                os.path.join(base_url, 'api/queries'),
-                json=query,
-                headers=headers,
-                timeout=7
-            )
+            resp = self.query_kowalski(query=query)
 
             if resp.status_code == requests.codes.ok:
                 alert_data = bj.loads(resp.text).get('data', list(dict()))
@@ -298,12 +546,7 @@ class ZTFAlertAuxHandler(ZTFAlertHandler):
                 }
             }
 
-            resp = s.post(
-                os.path.join(base_url, 'api/queries'),
-                json=query,
-                headers=headers,
-                timeout=7
-            )
+            resp = self.query_kowalski(query=query)
 
             if resp.status_code == requests.codes.ok:
                 latest_alert_data = bj.loads(resp.text).get('data', list(dict()))
@@ -420,16 +663,7 @@ class ZTFAlertCutoutHandler(ZTFAlertHandler):
                 }
             }
 
-            base_url = f"{self.cfg['app.kowalski.protocol']}://" \
-                       f"{self.cfg['app.kowalski.host']}:{self.cfg['app.kowalski.port']}"
-            headers = {"Authorization": f"Bearer {self.cfg['app.kowalski.token']}"}
-
-            resp = s.post(
-                os.path.join(base_url, 'api/queries'),
-                json=query,
-                headers=headers,
-                timeout=7
-            )
+            resp = self.query_kowalski(query=query)
 
             if resp.status_code == requests.codes.ok:
                 alert = bj.loads(resp.text).get('data', list(dict()))[0]

--- a/extensions/skyportal/skyportal/handlers/api/alert.py
+++ b/extensions/skyportal/skyportal/handlers/api/alert.py
@@ -1,4 +1,5 @@
 from astropy.io import fits
+from astropy.visualization import ZScaleInterval
 import base64
 import bson.json_util as bj
 import gzip
@@ -705,6 +706,20 @@ class ZTFAlertCutoutHandler(ZTFAlertHandler):
             schema:
               type: string
               enum: [fits, png]
+          - in: query
+            name: scaling
+            description: "Scaling to use when rendering png"
+            required: false
+            schema:
+              type: string
+              enum: [linear, log, arcsinh, zscale]
+          - in: query
+            name: cmap
+            description: "Color map to use when rendering png"
+            required: false
+            schema:
+              type: string
+              enum: [bone, gray, cividis, viridis, magma]
 
         responses:
           '200':
@@ -739,7 +754,9 @@ class ZTFAlertCutoutHandler(ZTFAlertHandler):
         try:
             candid = int(self.get_argument('candid'))
             cutout = self.get_argument('cutout').capitalize()
-            file_format = self.get_argument('file_format')
+            file_format = self.get_argument('file_format').lower()
+            scaling = self.get_argument('scaling', default=None)
+            cmap = self.get_argument('cmap', default=None)
 
             known_cutouts = ['Science', 'Template', 'Difference']
             if cutout not in known_cutouts:
@@ -749,6 +766,21 @@ class ZTFAlertCutoutHandler(ZTFAlertHandler):
                 return self.error(
                     f'file format {file_format} of {objectId}/{candid}/{cutout} not in {str(known_file_formats)}'
                 )
+
+            default_scaling = {
+                'Science': 'log',
+                'Template': 'log',
+                'Difference': 'zscale'
+            }
+            if (scaling is None) or (scaling.lower() not in ('log', 'linear', 'zscale', 'arcsinh')):
+                scaling = default_scaling[cutout]
+            else:
+                scaling = scaling.lower()
+
+            if (cmap is None) or (cmap.lower() not in ['bone', 'gray', 'cividis', 'viridis', 'magma']):
+                cmap = 'bone'
+            else:
+                cmap = cmap.lower()
 
             query = {
                 "query_type": "find",
@@ -812,11 +844,21 @@ class ZTFAlertCutoutHandler(ZTFAlertHandler):
                 img = np.array(data_flipped_y)
                 img = np.nan_to_num(img)
 
-                if cutout != 'Difference':
+                if scaling == 'log':
                     img[img <= 0] = np.median(img)
-                    ax.imshow(img, cmap='bone', norm=mplc.LogNorm(), origin='lower')
-                else:
-                    ax.imshow(img, cmap='bone', origin='lower')
+                    ax.imshow(img, cmap=cmap, norm=mplc.LogNorm(), origin='lower')
+                elif scaling == 'linear':
+                    ax.imshow(img, cmap=cmap, origin='lower')
+                elif scaling == 'zscale':
+                    interval = ZScaleInterval(
+                        nsamples=img.shape[0] * img.shape[1],
+                        contrast=0.045,
+                        krej=2.5
+                    )
+                    limits = interval.get_limits(img)
+                    ax.imshow(img, origin='lower', cmap=cmap, vmin=limits[0], vmax=limits[1])
+                elif scaling == 'arcsinh':
+                    ax.imshow(np.arcsinh(img - np.median(img)), cmap=cmap, origin='lower')
                 plt.savefig(buff, dpi=42)
 
                 buff.seek(0)

--- a/extensions/skyportal/skyportal/handlers/api/alert.py
+++ b/extensions/skyportal/skyportal/handlers/api/alert.py
@@ -457,7 +457,6 @@ class ZTFAlertHandler(BaseHandler):
             ztf_filters = {1: 'ztfg', 2: 'ztfr', 3: 'ztfi'}
             df['ztf_filter'] = df['fid'].apply(lambda x: ztf_filters[x])
             df['magsys'] = "ab"
-            df['zp'] = 25.0
             df['mjd'] = df['jd'] - 2400000.5
 
             photometry = {

--- a/extensions/skyportal/static/js/components/Filter.jsx
+++ b/extensions/skyportal/static/js/components/Filter.jsx
@@ -117,7 +117,7 @@ const Filter = () => {
   useEffect(() => {
     const fetchFilterVersion = async () => {
       const data = await dispatch(filterVersionActions.fetchFilterVersion(fid));
-      if ((data.status === "error") && !(data.message.includes("not found"))) {
+      if (data.status === "error" && !data.message.includes("not found")) {
         setFilterVersionLoadError(data.message);
         if (filterVersionLoadError.length > 1) {
           dispatch(showNotification(filterVersionLoadError, "error"));

--- a/extensions/skyportal/static/js/components/Filter.jsx
+++ b/extensions/skyportal/static/js/components/Filter.jsx
@@ -127,7 +127,7 @@ const Filter = () => {
     if (loadedId !== fid) {
       fetchFilterVersion();
     }
-  }, [fid, loadedId, dispatch]);
+  }, [fid, loadedId, dispatch, filterVersionLoadError]);
 
   const group_id = useSelector((state) => state.filter.group_id);
 
@@ -142,7 +142,7 @@ const Filter = () => {
       }
     };
     if (group_id) fetchGroup();
-  }, [group_id, dispatch]);
+  }, [group_id, dispatch, groupLoadError]);
 
   const filter = useSelector((state) => state.filter);
   const filter_v = useSelector((state) => state.filter_v);

--- a/extensions/skyportal/static/js/components/SaveAlertButton.jsx
+++ b/extensions/skyportal/static/js/components/SaveAlertButton.jsx
@@ -18,6 +18,7 @@ import MenuList from "@material-ui/core/MenuList";
 import { useForm, Controller } from "react-hook-form";
 
 import * as alertActions from "../ducks/alert";
+import * as sourcetActions from "../ducks/source";
 import FormValidationError from "./FormValidationError";
 
 const SaveAlertButton = ({ alert, userGroups }) => {
@@ -60,6 +61,7 @@ const SaveAlertButton = ({ alert, userGroups }) => {
     if (result.status === "success") {
       reset();
       setDialogOpen(false);
+      await dispatch(sourcetActions.fetchSource(alert.id));
     } else if (result.status === "error") {
       setIsSubmitting(false);
     }
@@ -89,6 +91,9 @@ const SaveAlertButton = ({ alert, userGroups }) => {
       const result = await dispatch(alertActions.saveAlertAsSource(data));
       if (result.status === "error") {
         setIsSubmitting(false);
+      }
+      else {
+        await dispatch(sourcetActions.fetchSource(alert.id));
       }
     } else if (selectedIndex === 1) {
       handleClickOpenDialog();

--- a/extensions/skyportal/static/js/components/SaveAlertButton.jsx
+++ b/extensions/skyportal/static/js/components/SaveAlertButton.jsx
@@ -17,10 +17,10 @@ import MenuItem from "@material-ui/core/MenuItem";
 import MenuList from "@material-ui/core/MenuList";
 import { useForm, Controller } from "react-hook-form";
 
-import * as sourceActions from "../ducks/source";
+import * as alertActions from "../ducks/alert";
 import FormValidationError from "./FormValidationError";
 
-const SaveCandidateButton = ({ candidate, userGroups }) => {
+const SaveAlertButton = ({ alert, userGroups }) => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   // Dialog logic:
 
@@ -32,10 +32,10 @@ const SaveCandidateButton = ({ candidate, userGroups }) => {
   useEffect(() => {
     reset({
       group_ids: userGroups.map((userGroup) =>
-        candidate.passing_group_ids.includes(userGroup.id)
+        alert.group_ids.includes(userGroup.id)
       ),
     });
-  }, [reset, userGroups, candidate]);
+  }, [reset, userGroups, alert]);
 
   const handleClickOpenDialog = () => {
     setDialogOpen(true);
@@ -52,11 +52,11 @@ const SaveCandidateButton = ({ candidate, userGroups }) => {
 
   const onSubmitGroupSelectSave = async (data) => {
     setIsSubmitting(true);
-    data.id = candidate.id;
+    data.id = alert.id;
     const groupIDs = userGroups.map((g) => g.id);
     const selectedGroupIDs = groupIDs.filter((ID, idx) => data.group_ids[idx]);
     data.group_ids = selectedGroupIDs;
-    const result = await dispatch(sourceActions.saveSource(data));
+    const result = await dispatch(alertActions.saveAlertAsSource(data));
     if (result.status === "success") {
       reset();
       setDialogOpen(false);
@@ -69,7 +69,7 @@ const SaveCandidateButton = ({ candidate, userGroups }) => {
   // https://material-ui.com/components/button-group/#split-button):
 
   const passingGroupNames = userGroups
-    .filter((g) => candidate.passing_group_ids.includes(g.id))
+    .filter((g) => alert.group_ids.includes(g.id))
     .map((g) => g.name.substring(0, 15) + (g.name.length > 15 ? "..." : ""))
     .join(", ");
 
@@ -83,10 +83,10 @@ const SaveCandidateButton = ({ candidate, userGroups }) => {
     if (selectedIndex === 0) {
       setIsSubmitting(true);
       const data = {
-        id: candidate.id,
-        group_ids: candidate.passing_group_ids,
+        id: alert.id,
+        group_ids: alert.group_ids,
       };
-      const result = await dispatch(sourceActions.saveSource(data));
+      const result = await dispatch(alertActions.saveAlertAsSource(data));
       if (result.status === "error") {
         setIsSubmitting(false);
       }
@@ -120,8 +120,8 @@ const SaveCandidateButton = ({ candidate, userGroups }) => {
       >
         <Button
           onClick={handleClickMainButton}
-          name={`initialSaveCandidateButton${candidate.id}`}
-          data-testid={`saveCandidateButton_${candidate.id}`}
+          name={`initialSaveAlertButton${alert.id}`}
+          data-testid={`saveAlertButton_${alert.id}`}
           disabled={isSubmitting}
         >
           {options[selectedIndex]}
@@ -132,7 +132,7 @@ const SaveCandidateButton = ({ candidate, userGroups }) => {
           aria-expanded={splitButtonMenuOpen ? "true" : undefined}
           aria-label="Save as Source"
           aria-haspopup="menu"
-          name={`saveCandidateButtonDropDownArrow${candidate.id}`}
+          name={`saveAlertButtonDropDownArrow${alert.id}`}
           onClick={handleToggleSplitButtonMenu}
         >
           <ArrowDropDownIcon />
@@ -144,6 +144,7 @@ const SaveCandidateButton = ({ candidate, userGroups }) => {
         role={undefined}
         transition
         disablePortal
+        style={{ zIndex: 1000 }}
       >
         {({ TransitionProps, placement }) => (
           <Grow
@@ -160,7 +161,7 @@ const SaveCandidateButton = ({ candidate, userGroups }) => {
                   {options.map((option, index) => (
                     <MenuItem
                       key={option}
-                      name={`buttonMenuOption${candidate.id}_${option}`}
+                      name={`buttonMenuOption${alert.id}_${option}`}
                       selected={index === selectedIndex}
                       onClick={(event) => handleMenuItemClick(event, index)}
                     >
@@ -204,7 +205,7 @@ const SaveCandidateButton = ({ candidate, userGroups }) => {
               <Button
                 variant="contained"
                 type="submit"
-                name={`finalSaveCandidateButton${candidate.id}`}
+                name={`finalSaveAlertButton${alert.id}`}
               >
                 Save
               </Button>
@@ -215,10 +216,10 @@ const SaveCandidateButton = ({ candidate, userGroups }) => {
     </div>
   );
 };
-SaveCandidateButton.propTypes = {
-  candidate: PropTypes.shape({
+SaveAlertButton.propTypes = {
+  alert: PropTypes.shape({
     id: PropTypes.string,
-    passing_group_ids: PropTypes.arrayOf(PropTypes.number),
+    group_ids: PropTypes.arrayOf(PropTypes.number),
   }).isRequired,
   userGroups: PropTypes.arrayOf(
     PropTypes.shape({
@@ -228,4 +229,4 @@ SaveCandidateButton.propTypes = {
   ).isRequired,
 };
 
-export default SaveCandidateButton;
+export default SaveAlertButton;

--- a/extensions/skyportal/static/js/components/SaveAlertButton.jsx
+++ b/extensions/skyportal/static/js/components/SaveAlertButton.jsx
@@ -18,7 +18,7 @@ import MenuList from "@material-ui/core/MenuList";
 import { useForm, Controller } from "react-hook-form";
 
 import * as alertActions from "../ducks/alert";
-import * as sourcetActions from "../ducks/source";
+import * as sourceActions from "../ducks/source";
 import FormValidationError from "./FormValidationError";
 
 const SaveAlertButton = ({ alert, userGroups }) => {
@@ -63,7 +63,7 @@ const SaveAlertButton = ({ alert, userGroups }) => {
     } else {
       setDialogOpen(false);
       reset();
-      await dispatch(sourcetActions.fetchSource(alert.id));
+      await dispatch(sourceActions.fetchSource(alert.id));
     }
   };
 

--- a/extensions/skyportal/static/js/components/SaveAlertButton.jsx
+++ b/extensions/skyportal/static/js/components/SaveAlertButton.jsx
@@ -91,8 +91,7 @@ const SaveAlertButton = ({ alert, userGroups }) => {
       const result = await dispatch(alertActions.saveAlertAsSource(data));
       if (result.status === "error") {
         setIsSubmitting(false);
-      }
-      else {
+      } else {
         await dispatch(sourcetActions.fetchSource(alert.id));
       }
     } else if (selectedIndex === 1) {

--- a/extensions/skyportal/static/js/components/SaveAlertButton.jsx
+++ b/extensions/skyportal/static/js/components/SaveAlertButton.jsx
@@ -1,0 +1,231 @@
+import React, { useState, useEffect, useRef } from "react";
+import PropTypes from "prop-types";
+import { useDispatch } from "react-redux";
+import Dialog from "@material-ui/core/Dialog";
+import DialogContent from "@material-ui/core/DialogContent";
+import DialogTitle from "@material-ui/core/DialogTitle";
+import Checkbox from "@material-ui/core/Checkbox";
+import Button from "@material-ui/core/Button";
+import ButtonGroup from "@material-ui/core/ButtonGroup";
+import FormControlLabel from "@material-ui/core/FormControlLabel";
+import ArrowDropDownIcon from "@material-ui/icons/ArrowDropDown";
+import ClickAwayListener from "@material-ui/core/ClickAwayListener";
+import Grow from "@material-ui/core/Grow";
+import Paper from "@material-ui/core/Paper";
+import Popper from "@material-ui/core/Popper";
+import MenuItem from "@material-ui/core/MenuItem";
+import MenuList from "@material-ui/core/MenuList";
+import { useForm, Controller } from "react-hook-form";
+
+import * as sourceActions from "../ducks/source";
+import FormValidationError from "./FormValidationError";
+
+const SaveCandidateButton = ({ candidate, userGroups }) => {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  // Dialog logic:
+
+  const dispatch = useDispatch();
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const { handleSubmit, errors, reset, control, getValues } = useForm();
+
+  useEffect(() => {
+    reset({
+      group_ids: userGroups.map((userGroup) =>
+        candidate.passing_group_ids.includes(userGroup.id)
+      ),
+    });
+  }, [reset, userGroups, candidate]);
+
+  const handleClickOpenDialog = () => {
+    setDialogOpen(true);
+  };
+
+  const handleCloseDialog = () => {
+    setDialogOpen(false);
+  };
+
+  const validateGroups = () => {
+    const formState = getValues({ nest: true });
+    return formState.group_ids.filter((value) => Boolean(value)).length >= 1;
+  };
+
+  const onSubmitGroupSelectSave = async (data) => {
+    setIsSubmitting(true);
+    data.id = candidate.id;
+    const groupIDs = userGroups.map((g) => g.id);
+    const selectedGroupIDs = groupIDs.filter((ID, idx) => data.group_ids[idx]);
+    data.group_ids = selectedGroupIDs;
+    const result = await dispatch(sourceActions.saveSource(data));
+    if (result.status === "success") {
+      reset();
+      setDialogOpen(false);
+    } else if (result.status === "error") {
+      setIsSubmitting(false);
+    }
+  };
+
+  // Split button logic (largely copied from
+  // https://material-ui.com/components/button-group/#split-button):
+
+  const passingGroupNames = userGroups
+    .filter((g) => candidate.passing_group_ids.includes(g.id))
+    .map((g) => g.name.substring(0, 15) + (g.name.length > 15 ? "..." : ""))
+    .join(", ");
+
+  const options = [`Save to ${passingGroupNames}`, "Select groups & save"];
+
+  const [splitButtonMenuOpen, setSplitButtonMenuOpen] = useState(false);
+  const anchorRef = useRef(null);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  const handleClickMainButton = async () => {
+    if (selectedIndex === 0) {
+      setIsSubmitting(true);
+      const data = {
+        id: candidate.id,
+        group_ids: candidate.passing_group_ids,
+      };
+      const result = await dispatch(sourceActions.saveSource(data));
+      if (result.status === "error") {
+        setIsSubmitting(false);
+      }
+    } else if (selectedIndex === 1) {
+      handleClickOpenDialog();
+    }
+  };
+
+  const handleMenuItemClick = (event, index) => {
+    setSelectedIndex(index);
+    setSplitButtonMenuOpen(false);
+  };
+
+  const handleToggleSplitButtonMenu = () => {
+    setSplitButtonMenuOpen((prevOpen) => !prevOpen);
+  };
+
+  const handleCloseSplitButtonMenu = (event) => {
+    if (anchorRef.current && anchorRef.current.contains(event.target)) {
+      return;
+    }
+    setSplitButtonMenuOpen(false);
+  };
+
+  return (
+    <div>
+      <ButtonGroup
+        variant="contained"
+        ref={anchorRef}
+        aria-label="split button"
+      >
+        <Button
+          onClick={handleClickMainButton}
+          name={`initialSaveCandidateButton${candidate.id}`}
+          data-testid={`saveCandidateButton_${candidate.id}`}
+          disabled={isSubmitting}
+        >
+          {options[selectedIndex]}
+        </Button>
+        <Button
+          size="small"
+          aria-controls={splitButtonMenuOpen ? "split-button-menu" : undefined}
+          aria-expanded={splitButtonMenuOpen ? "true" : undefined}
+          aria-label="Save as Source"
+          aria-haspopup="menu"
+          name={`saveCandidateButtonDropDownArrow${candidate.id}`}
+          onClick={handleToggleSplitButtonMenu}
+        >
+          <ArrowDropDownIcon />
+        </Button>
+      </ButtonGroup>
+      <Popper
+        open={splitButtonMenuOpen}
+        anchorEl={anchorRef.current}
+        role={undefined}
+        transition
+        disablePortal
+      >
+        {({ TransitionProps, placement }) => (
+          <Grow
+            /* eslint-disable-next-line react/jsx-props-no-spreading */
+            {...TransitionProps}
+            style={{
+              transformOrigin:
+                placement === "bottom" ? "center top" : "center bottom",
+            }}
+          >
+            <Paper>
+              <ClickAwayListener onClickAway={handleCloseSplitButtonMenu}>
+                <MenuList id="split-button-menu">
+                  {options.map((option, index) => (
+                    <MenuItem
+                      key={option}
+                      name={`buttonMenuOption${candidate.id}_${option}`}
+                      selected={index === selectedIndex}
+                      onClick={(event) => handleMenuItemClick(event, index)}
+                    >
+                      {option}
+                    </MenuItem>
+                  ))}
+                </MenuList>
+              </ClickAwayListener>
+            </Paper>
+          </Grow>
+        )}
+      </Popper>
+
+      <Dialog
+        open={dialogOpen}
+        onClose={handleCloseDialog}
+        style={{ position: "fixed" }}
+      >
+        <DialogTitle>Select one or more groups:</DialogTitle>
+        <DialogContent>
+          <form onSubmit={handleSubmit(onSubmitGroupSelectSave)}>
+            {errors.group_ids && (
+              <FormValidationError message="Select at least one group." />
+            )}
+            {userGroups.map((userGroup, idx) => (
+              <FormControlLabel
+                key={userGroup.id}
+                control={
+                  <Controller
+                    as={Checkbox}
+                    name={`group_ids[${idx}]`}
+                    control={control}
+                    rules={{ validate: validateGroups }}
+                  />
+                }
+                label={userGroup.name}
+              />
+            ))}
+            <br />
+            <div style={{ textAlign: "center" }}>
+              <Button
+                variant="contained"
+                type="submit"
+                name={`finalSaveCandidateButton${candidate.id}`}
+              >
+                Save
+              </Button>
+            </div>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+};
+SaveCandidateButton.propTypes = {
+  candidate: PropTypes.shape({
+    id: PropTypes.string,
+    passing_group_ids: PropTypes.arrayOf(PropTypes.number),
+  }).isRequired,
+  userGroups: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number,
+      name: PropTypes.string,
+    })
+  ).isRequired,
+};
+
+export default SaveCandidateButton;

--- a/extensions/skyportal/static/js/components/SaveAlertButton.jsx
+++ b/extensions/skyportal/static/js/components/SaveAlertButton.jsx
@@ -56,14 +56,16 @@ const SaveAlertButton = ({ alert, userGroups }) => {
     data.id = alert.id;
     const groupIDs = userGroups.map((g) => g.id);
     const selectedGroupIDs = groupIDs.filter((ID, idx) => data.group_ids[idx]);
-    data.group_ids = selectedGroupIDs;
+
+    data.payload = {candid: alert.candid, group_ids: selectedGroupIDs};
+
     const result = await dispatch(alertActions.saveAlertAsSource(data));
-    if (result.status === "success") {
-      reset();
-      setDialogOpen(false);
-      await dispatch(sourcetActions.fetchSource(alert.id));
-    } else if (result.status === "error") {
+    if (result.status === "error") {
       setIsSubmitting(false);
+    } else {
+      setDialogOpen(false);
+      reset();
+      await dispatch(sourcetActions.fetchSource(alert.id));
     }
   };
 
@@ -86,7 +88,7 @@ const SaveAlertButton = ({ alert, userGroups }) => {
       setIsSubmitting(true);
       const data = {
         id: alert.id,
-        group_ids: alert.group_ids,
+        payload: {candid: alert.candid, group_ids: alert.group_ids},
       };
       const result = await dispatch(alertActions.saveAlertAsSource(data));
       if (result.status === "error") {

--- a/extensions/skyportal/static/js/components/SaveAlertButton.jsx
+++ b/extensions/skyportal/static/js/components/SaveAlertButton.jsx
@@ -32,9 +32,7 @@ const SaveAlertButton = ({ alert, userGroups }) => {
 
   useEffect(() => {
     reset({
-      group_ids: userGroups.map((userGroup) =>
-        alert.group_ids.includes(userGroup.id)
-      ),
+      group_ids: []
     });
   }, [reset, userGroups, alert]);
 
@@ -72,12 +70,8 @@ const SaveAlertButton = ({ alert, userGroups }) => {
   // Split button logic (largely copied from
   // https://material-ui.com/components/button-group/#split-button):
 
-  const passingGroupNames = userGroups
-    .filter((g) => alert.group_ids.includes(g.id))
-    .map((g) => g.name.substring(0, 15) + (g.name.length > 15 ? "..." : ""))
-    .join(", ");
-
-  const options = [`Save to ${passingGroupNames}`, "Select groups & save"];
+  const options = ["Select groups & save as a source"];
+  // const options = ["Select groups & save as a source", "Select filters & save as a candidate"];
 
   const [splitButtonMenuOpen, setSplitButtonMenuOpen] = useState(false);
   const anchorRef = useRef(null);
@@ -85,18 +79,6 @@ const SaveAlertButton = ({ alert, userGroups }) => {
 
   const handleClickMainButton = async () => {
     if (selectedIndex === 0) {
-      setIsSubmitting(true);
-      const data = {
-        id: alert.id,
-        payload: {candid: alert.candid, group_ids: alert.group_ids},
-      };
-      const result = await dispatch(alertActions.saveAlertAsSource(data));
-      if (result.status === "error") {
-        setIsSubmitting(false);
-      } else {
-        await dispatch(sourcetActions.fetchSource(alert.id));
-      }
-    } else if (selectedIndex === 1) {
       handleClickOpenDialog();
     }
   };
@@ -201,6 +183,7 @@ const SaveAlertButton = ({ alert, userGroups }) => {
                     name={`group_ids[${idx}]`}
                     control={control}
                     rules={{ validate: validateGroups }}
+                    defaultValue={false}
                   />
                 }
                 label={userGroup.name}

--- a/extensions/skyportal/static/js/components/ZTFAlert.jsx
+++ b/extensions/skyportal/static/js/components/ZTFAlert.jsx
@@ -129,6 +129,8 @@ const ZTFAlert = ({ route }) => {
     method: "GET"
   };
 
+  const loadedSourceId = useSelector((state) => state?.source?.id);
+
   useEffect(() => {
     const fetchSource = async () => {
 
@@ -410,7 +412,7 @@ const columns = [
             </div>
             <div className={classes.name}>{objectId}</div>
             <br />
-            {savedSource ? (
+            {savedSource || loadedSourceId ? (
               <div className={classes.itemPaddingBottom}>
                 <Chip
                   size="small"

--- a/extensions/skyportal/static/js/components/ZTFAlert.jsx
+++ b/extensions/skyportal/static/js/components/ZTFAlert.jsx
@@ -273,6 +273,16 @@ const ZTFAlert = ({ route }) => {
       id: 2,
       public_url: `/api/alerts/ztf/${objectId}/cutout?candid=${candid}&cutout=difference&file_format=png`,
     },
+    // {
+    //   type: "sdss",
+    //   id: 3,
+    //   public_url: `http://skyserver.sdss.org/dr12/SkyserverWS/ImgCutout/getjpeg?ra=${alert_data.filter((a) => a.candid === candid)[0].candidate.ra}&dec=${alert_data.filter((a) => a.candid === candid)[0].candidate.dec}&scale=0.3&width=200&height=200&opt=G&query=&Grid=on`
+    // },
+    // {
+    //   type: "dr8",
+    //   id: 4,
+    //   public_url: `http://legacysurvey.org/viewer/jpeg-cutout?ra=${alert_data.filter((a) => a.candid === candid)[0].candidate.ra}&dec=${alert_data.filter((a) => a.candid === candid)[0].candidate.dec}&size=200&layer=dr8&pixscale=0.262&bands=grz`
+    // },
   ];
 
   const options = {
@@ -507,9 +517,10 @@ const ZTFAlert = ({ route }) => {
                 >
                   {candid > 0 && (
                     <ThumbnailList
-                      ra={0}
-                      dec={0}
+                      ra={alert_data.filter((a) => a.candid === candid)[0].candidate.ra}
+                      dec={alert_data.filter((a) => a.candid === candid)[0].candidate.dec}
                       thumbnails={thumbnails}
+                      displayTypes={["new", "ref", "sub"]}
                       size="10rem"
                     />
                   )}

--- a/extensions/skyportal/static/js/components/ZTFAlert.jsx
+++ b/extensions/skyportal/static/js/components/ZTFAlert.jsx
@@ -22,10 +22,10 @@ import Chip from "@material-ui/core/Chip";
 import OpenInNewIcon from "@material-ui/icons/OpenInNew";
 
 import MUIDataTable from "mui-datatables";
+import ReactJson from "react-json-view";
 
 import SaveAlertButton from "./SaveAlertButton";
 import ThumbnailList from "./ThumbnailList";
-import ReactJson from "react-json-view";
 
 import { ra_to_hours, dec_to_hours } from "../units";
 import SharePage from "./SharePage";
@@ -128,7 +128,7 @@ const ZTFAlert = ({ route }) => {
   const [savedSource, setsavedSource] = useState(false);
 
   // not using API/source duck as that would throw an error if source does not exist
-  let fetchInit = {
+  const fetchInit = {
     credentials: "same-origin",
     headers: {
       "Content-Type": "application/json",
@@ -155,7 +155,7 @@ const ZTFAlert = ({ route }) => {
     };
 
     fetchSource();
-  }, [objectId, dispatch]);
+  }, [objectId, dispatch, fetchInit]);
 
   const userAccessibleGroups = useSelector(
     (state) => state.groups.userAccessible
@@ -498,8 +498,8 @@ const ZTFAlert = ({ route }) => {
                   lg={6}
                   spacing={1}
                   className={classes.image}
-                  alignItems={"stretch"}
-                  alignContent={"stretch"}
+                  alignItems="stretch"
+                  alignContent="stretch"
                 >
                   {candid > 0 && (
                     <ThumbnailList
@@ -517,7 +517,7 @@ const ZTFAlert = ({ route }) => {
           <Paper className={classes.root}>
             <MuiThemeProvider theme={getMuiTheme(theme)}>
               <MUIDataTable
-                title={"Alerts"}
+                title="Alerts"
                 data={rows}
                 columns={columns}
                 options={options}

--- a/extensions/skyportal/static/js/components/ZTFAlert.jsx
+++ b/extensions/skyportal/static/js/components/ZTFAlert.jsx
@@ -126,6 +126,7 @@ const ZTFAlert = ({ route }) => {
 
   // figure out if this objectId has been saved as Source.
   const [savedSource, setsavedSource] = useState(false);
+  const [checkedIfSourceSaved, setsCheckedIfSourceSaved] = useState(false);
 
   // not using API/source duck as that would throw an error if source does not exist
   const fetchInit = {
@@ -152,9 +153,12 @@ const ZTFAlert = ({ route }) => {
       if (json.status === "success") {
         setsavedSource(true);
       }
+      setsCheckedIfSourceSaved(true)
     };
 
-    fetchSource();
+    if (!checkedIfSourceSaved) {
+      fetchSource();
+    }
   }, [objectId, dispatch, fetchInit]);
 
   const userAccessibleGroups = useSelector(
@@ -430,7 +434,7 @@ const ZTFAlert = ({ route }) => {
                 <br />
                 <div className={classes.saveAlertButton}>
                   <SaveAlertButton
-                    alert={{ id: objectId, group_ids: userAccessibleGroupIds }}
+                    alert={{ id: objectId, candid: parseInt(candid), group_ids: userAccessibleGroupIds }}
                     userGroups={userAccessibleGroups}
                   />
                 </div>

--- a/extensions/skyportal/static/js/components/ZTFAlert.jsx
+++ b/extensions/skyportal/static/js/components/ZTFAlert.jsx
@@ -1,10 +1,15 @@
 import React, { useEffect, useState, Suspense } from "react";
 import { useDispatch, useSelector } from "react-redux";
+import { useHistory } from "react-router-dom";
 
 import Button from "@material-ui/core/Button";
-import SaveIcon from "@material-ui/icons/Save";
 import PropTypes from "prop-types";
-import { makeStyles, useTheme, createMuiTheme, MuiThemeProvider } from "@material-ui/core/styles";
+import {
+  makeStyles,
+  useTheme,
+  createMuiTheme,
+  MuiThemeProvider,
+} from "@material-ui/core/styles";
 import Paper from "@material-ui/core/Paper";
 import Grid from "@material-ui/core/Grid";
 import Accordion from "@material-ui/core/Accordion";
@@ -25,7 +30,6 @@ import ReactJson from "react-json-view";
 import { ra_to_hours, dec_to_hours } from "../units";
 import SharePage from "./SharePage";
 
-// import * as SourceAction from "../ducks/source";
 import * as Actions from "../ducks/alert";
 
 const VegaPlotZTFAlert = React.lazy(() => import("./VegaPlotZTFAlert"));
@@ -107,7 +111,9 @@ const getMuiTheme = (theme) =>
     overrides: {
       MUIDataTableBodyCell: {
         root: {
-          padding: `${theme.spacing(0.25)}px 0px ${theme.spacing(0.25)}px ${theme.spacing(1)}px`,
+          padding: `${theme.spacing(0.25)}px 0px ${theme.spacing(
+            0.25
+          )}px ${theme.spacing(1)}px`,
         },
       },
     },
@@ -116,6 +122,7 @@ const getMuiTheme = (theme) =>
 const ZTFAlert = ({ route }) => {
   const objectId = route.id;
   const dispatch = useDispatch();
+  const history = useHistory();
 
   // figure out if this objectId has been saved as Source.
   const [savedSource, setsavedSource] = useState(false);
@@ -126,14 +133,13 @@ const ZTFAlert = ({ route }) => {
     headers: {
       "Content-Type": "application/json",
     },
-    method: "GET"
+    method: "GET",
   };
 
   const loadedSourceId = useSelector((state) => state?.source?.id);
 
   useEffect(() => {
     const fetchSource = async () => {
-
       const response = await fetch(`/api/sources/${objectId}`, fetchInit);
 
       let json = "";
@@ -144,7 +150,7 @@ const ZTFAlert = ({ route }) => {
       }
 
       if (json.status === "success") {
-        setsavedSource(true)
+        setsavedSource(true);
       }
     };
 
@@ -155,8 +161,8 @@ const ZTFAlert = ({ route }) => {
     (state) => state.groups.userAccessible
   );
 
-  const userAccessibleGroupIds = useSelector(
-    (state) => state.groups.userAccessible?.map((a) => a.id)
+  const userAccessibleGroupIds = useSelector((state) =>
+    state.groups.userAccessible?.map((a) => a.id)
   );
 
   const theme = useTheme();
@@ -187,18 +193,18 @@ const ZTFAlert = ({ route }) => {
 
   const makeRow = (alert) => {
     return {
-      "candid": alert?.candid,
-      "jd": alert?.candidate.jd,
-      "fid": alert?.candidate.fid,
-      "mag": alert?.candidate.magpsf,
-      "emag": alert?.candidate.sigmapsf,
-      "rb": alert?.candidate.rb,
-      "drb": alert?.candidate.drb,
-      "isdiffpos": alert?.candidate.isdiffpos,
-      "programid": alert?.candidate.programid,
-      "alert_actions": "show thumbnails",
-    }
-  }
+      candid: alert?.candid,
+      jd: alert?.candidate.jd,
+      fid: alert?.candidate.fid,
+      mag: alert?.candidate.magpsf,
+      emag: alert?.candidate.sigmapsf,
+      rb: alert?.candidate.rb,
+      drb: alert?.candidate.drb,
+      isdiffpos: alert?.candidate.isdiffpos,
+      programid: alert?.candidate.programid,
+      alert_actions: "show thumbnails",
+    };
+  };
 
   let rows = [];
 
@@ -270,125 +276,119 @@ const ZTFAlert = ({ route }) => {
     elevation: 1,
     sortOrder: {
       name: "jd",
-      direction: "desc"
+      direction: "desc",
     },
-  }
+  };
 
-const columns = [
-  {
-    name: "candid",
-    label: "candid",
-    options: {
-      filter: false,
-      sort: true,
-      sortDescFirst: true,
-    }
-  },
-  {
-    name: "jd",
-    label: "JD",
-    options: {
-      filter: false,
-      sort: true,
-      sortDescFirst: true,
-      customBodyRender: (value, tableMeta, updateValue) => (
-        value.toFixed(5)
-      )
-    }
-  },
-  {
-    name: "fid",
-    label: "fid",
-    options: {
-      filter: true,
-      sort: true,
-    }
-  },
-  {
-    name: "mag",
-    label: "mag",
-    options: {
-      filter: false,
-      sort: true,
-      customBodyRender: (value, tableMeta, updateValue) => (
-        value.toFixed(3)
-      )
-    }
-  },
-  {
-    name: "emag",
-    label: "e_mag",
-    options: {
-      filter: false,
-      sort: true,
-      customBodyRender: (value, tableMeta, updateValue) => (
-        value.toFixed(3)
-      )
-    }
-  },
-  {
-    name: "rb",
-    label: "rb",
-    options: {
-      filter: false,
-      sort: true,
-      sortDescFirst: true,
-      customBodyRender: (value, tableMeta, updateValue) => (
-        value.toFixed(5)
-      )
-    }
-  },
-  {
-    name: "drb",
-    label: "drb",
-    options: {
-      filter: false,
-      sort: true,
-      sortDescFirst: true,
-      customBodyRender: (value, tableMeta, updateValue) => (
-        value.toFixed(5)
-      )
-    }
-  },
-  {
-    name: "isdiffpos",
-    label: "isdiffpos",
-    options: {
-      filter: true,
-      sort: true,
-    }
-  },
-  {
-    name: "programid",
-    label: "programid",
-    options: {
-      filter: true,
-      sort: true,
-    }
-  },
-  {
-    name: "alert_actions",
-    label: "actions",
-    options: {
-      filter: false,
-      sort: false,
-      customBodyRender: (value, tableMeta, updateValue) => (
-        <Button
-          size="small"
-          onClick={() => {
-            setCandid(tableMeta.rowData[0]);
-            setJd(tableMeta.rowData[1]);
-          }}
-        >
-          Show&nbsp;thumbnails
-        </Button>
-      )
-    }
-  },
-];
+  const columns = [
+    {
+      name: "candid",
+      label: "candid",
+      options: {
+        filter: false,
+        sort: true,
+        sortDescFirst: true,
+      },
+    },
+    {
+      name: "jd",
+      label: "JD",
+      options: {
+        filter: false,
+        sort: true,
+        sortDescFirst: true,
+        customBodyRender: (value, tableMeta, updateValue) => value.toFixed(5),
+      },
+    },
+    {
+      name: "fid",
+      label: "fid",
+      options: {
+        filter: true,
+        sort: true,
+      },
+    },
+    {
+      name: "mag",
+      label: "mag",
+      options: {
+        filter: false,
+        sort: true,
+        customBodyRender: (value, tableMeta, updateValue) => value.toFixed(3),
+      },
+    },
+    {
+      name: "emag",
+      label: "e_mag",
+      options: {
+        filter: false,
+        sort: true,
+        customBodyRender: (value, tableMeta, updateValue) => value.toFixed(3),
+      },
+    },
+    {
+      name: "rb",
+      label: "rb",
+      options: {
+        filter: false,
+        sort: true,
+        sortDescFirst: true,
+        customBodyRender: (value, tableMeta, updateValue) => value.toFixed(5),
+      },
+    },
+    {
+      name: "drb",
+      label: "drb",
+      options: {
+        filter: false,
+        sort: true,
+        sortDescFirst: true,
+        customBodyRender: (value, tableMeta, updateValue) => value.toFixed(5),
+      },
+    },
+    {
+      name: "isdiffpos",
+      label: "isdiffpos",
+      options: {
+        filter: true,
+        sort: true,
+      },
+    },
+    {
+      name: "programid",
+      label: "programid",
+      options: {
+        filter: true,
+        sort: true,
+      },
+    },
+    {
+      name: "alert_actions",
+      label: "actions",
+      options: {
+        filter: false,
+        sort: false,
+        customBodyRender: (value, tableMeta, updateValue) => (
+          <Button
+            size="small"
+            onClick={() => {
+              setCandid(tableMeta.rowData[0]);
+              setJd(tableMeta.rowData[1]);
+            }}
+          >
+            Show&nbsp;thumbnails
+          </Button>
+        ),
+      },
+    },
+  ];
 
   if (alert_data === null) {
-    return <div><CircularProgress color="secondary" /></div>;
+    return (
+      <div>
+        <CircularProgress color="secondary" />
+      </div>
+    );
   }
   if (isString(alert_data) || isString(alert_aux_data)) {
     return <div>Failed to fetch alert data, please try again later.</div>;
@@ -419,23 +419,18 @@ const columns = [
                   label="Previously Saved"
                   clickable
                   onClick={() => history.push(`/source/${objectId}`)}
-                  onDelete={() =>
-                    window.open(`/source/${objectId}`, "_blank")
-                  }
+                  onDelete={() => window.open(`/source/${objectId}`, "_blank")}
                   deleteIcon={<OpenInNewIcon />}
                   color="primary"
                 />
               </div>
             ) : (
               <div className={classes.itemPaddingBottom}>
-                <Chip
-                  size="small"
-                  label="NOT SAVED"
-                />
+                <Chip size="small" label="NOT SAVED" />
                 <br />
                 <div className={classes.saveAlertButton}>
                   <SaveAlertButton
-                    alert={{id: objectId, group_ids: userAccessibleGroupIds}}
+                    alert={{ id: objectId, group_ids: userAccessibleGroupIds }}
                     userGroups={userAccessibleGroups}
                   />
                 </div>
@@ -443,21 +438,32 @@ const columns = [
             )}
             {candid > 0 && (
               <>
-              <b>candid:</b>
-              &nbsp;
-              {candid}
-              <br />
-              <b>Position (J2000):</b>
-              &nbsp;
-              {alert_data.filter((a) => a.candid === candid)[0].candidate.ra}, &nbsp;
-              {alert_data.filter((a) => a.candid === candid)[0].candidate.dec}
-              &nbsp; (&alpha;,&delta;=
-              {ra_to_hours(alert_data.filter((a) => a.candid === candid)[0].candidate.ra)}, &nbsp;
-              {dec_to_hours(alert_data.filter((a) => a.candid === candid)[0].candidate.dec)}) &nbsp;
-              (l,b=
-              {alert_data.filter((a) => a.candid === candid)[0].coordinates.l.toFixed(6)}, &nbsp;
-              {alert_data.filter((a) => a.candid === candid)[0].coordinates.b.toFixed(6)}
-              )
+                <b>candid:</b>
+                &nbsp;
+                {candid}
+                <br />
+                <b>Position (J2000):</b>
+                &nbsp;
+                {alert_data.filter((a) => a.candid === candid)[0].candidate.ra},
+                &nbsp;
+                {alert_data.filter((a) => a.candid === candid)[0].candidate.dec}
+                &nbsp; (&alpha;,&delta;=
+                {ra_to_hours(
+                  alert_data.filter((a) => a.candid === candid)[0].candidate.ra
+                )}
+                , &nbsp;
+                {dec_to_hours(
+                  alert_data.filter((a) => a.candid === candid)[0].candidate.dec
+                )}
+                ) &nbsp; (l,b=
+                {alert_data
+                  .filter((a) => a.candid === candid)[0]
+                  .coordinates.l.toFixed(6)}
+                , &nbsp;
+                {alert_data
+                  .filter((a) => a.candid === candid)[0]
+                  .coordinates.b.toFixed(6)}
+                )
               </>
             )}
           </div>
@@ -528,10 +534,16 @@ const columns = [
               aria-controls="panel-content"
               id="panel-header"
             >
-              <Typography className={classes.accordionHeading}>Cross-matches</Typography>
+              <Typography className={classes.accordionHeading}>
+                Cross-matches
+              </Typography>
             </AccordionSummary>
             <AccordionDetails className={classes.accordion_details}>
-              <ReactJson src={cross_matches} name={false} theme={darkTheme ? "monokai" : "rjv-default"}/>
+              <ReactJson
+                src={cross_matches}
+                name={false}
+                theme={darkTheme ? "monokai" : "rjv-default"}
+              />
             </AccordionDetails>
           </Accordion>
         </div>

--- a/extensions/skyportal/static/js/components/ZTFAlert.jsx
+++ b/extensions/skyportal/static/js/components/ZTFAlert.jsx
@@ -4,15 +4,7 @@ import { useDispatch, useSelector } from "react-redux";
 import Button from "@material-ui/core/Button";
 import SaveIcon from "@material-ui/icons/Save";
 import PropTypes from "prop-types";
-import { withStyles, makeStyles, useTheme } from "@material-ui/core/styles";
-import Table from "@material-ui/core/Table";
-import TableBody from "@material-ui/core/TableBody";
-import TableCell from "@material-ui/core/TableCell";
-import TableContainer from "@material-ui/core/TableContainer";
-import TableHead from "@material-ui/core/TableHead";
-import TablePagination from "@material-ui/core/TablePagination";
-import TableRow from "@material-ui/core/TableRow";
-import TableSortLabel from "@material-ui/core/TableSortLabel";
+import { makeStyles, useTheme, createMuiTheme, MuiThemeProvider } from "@material-ui/core/styles";
 import Paper from "@material-ui/core/Paper";
 import Grid from "@material-ui/core/Grid";
 import Accordion from "@material-ui/core/Accordion";
@@ -22,18 +14,14 @@ import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 import Typography from "@material-ui/core/Typography";
 import CircularProgress from "@material-ui/core/CircularProgress";
 
+import MUIDataTable from "mui-datatables";
+
 import ThumbnailList from "./ThumbnailList";
 import ReactJson from "react-json-view";
 
 import * as Actions from "../ducks/alert";
 
-const VegaPlot = React.lazy(() => import("./VegaPlotZTFAlert"));
-
-const StyledTableCell = withStyles(() => ({
-  body: {
-    fontSize: "0.875rem",
-  },
-}))(TableCell);
+const VegaPlotZTFAlert = React.lazy(() => import("./VegaPlotZTFAlert"));
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -45,17 +33,7 @@ const useStyles = makeStyles((theme) => ({
   whitish: {
     color: "#f0f0f0",
   },
-  visuallyHidden: {
-    border: 0,
-    clip: "rect(0 0 0 0)",
-    height: 1,
-    margin: -1,
-    overflow: "hidden",
-    padding: 0,
-    position: "absolute",
-    top: 20,
-    width: 1,
-  },
+
   margin_bottom: {
     "margin-bottom": "2em",
   },
@@ -82,182 +60,20 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-function createRows(
-  id,
-  jd,
-  fid,
-  mag,
-  emag,
-  rb,
-  drb,
-  isdiffpos,
-  programid,
-  alert_actions
-) {
-  return {
-    id,
-    jd,
-    fid,
-    mag,
-    emag,
-    rb,
-    drb,
-    isdiffpos,
-    programid,
-    alert_actions,
-  };
-}
-
-const columns = [
-  {
-    id: "id",
-    label: "candid",
-    numeric: false,
-    disablePadding: false,
-  },
-  {
-    id: "jd",
-    numeric: true,
-    disablePadding: false,
-    label: "JD",
-    align: "left",
-    format: (value) => value.toFixed(5),
-  },
-  {
-    id: "fid",
-    numeric: true,
-    disablePadding: false,
-    label: "fid",
-    align: "left",
-  },
-  {
-    id: "mag",
-    numeric: true,
-    disablePadding: false,
-    label: "mag",
-    align: "left",
-    format: (value) => value.toFixed(3),
-  },
-  {
-    id: "emag",
-    numeric: true,
-    disablePadding: false,
-    label: "e_mag",
-    align: "left",
-    format: (value) => value.toFixed(3),
-  },
-  {
-    id: "rb",
-    numeric: true,
-    disablePadding: false,
-    label: "rb",
-    align: "left",
-    format: (value) => value.toFixed(5),
-  },
-  {
-    id: "drb",
-    numeric: true,
-    disablePadding: false,
-    label: "drb",
-    align: "left",
-    format: (value) => value.toFixed(5),
-  },
-  {
-    id: "isdiffpos",
-    numeric: false,
-    disablePadding: false,
-    label: "isdiffpos",
-    align: "left",
-  },
-  {
-    id: "programid",
-    numeric: true,
-    disablePadding: false,
-    label: "programid",
-    align: "left",
-  },
-  {
-    id: "alert_actions",
-    numeric: false,
-    disablePadding: false,
-    label: "actions",
-    align: "right",
-  },
-];
-
-function descendingComparator(a, b, orderBy) {
-  if (b[orderBy] < a[orderBy]) {
-    return -1;
-  }
-  if (b[orderBy] > a[orderBy]) {
-    return 1;
-  }
-  return 0;
-}
-
-function getComparator(order, orderBy) {
-  return order === "desc"
-    ? (a, b) => descendingComparator(a, b, orderBy)
-    : (a, b) => -descendingComparator(a, b, orderBy);
-}
-
-function stableSort(array, comparator) {
-  const stabilizedThis = array.map((el, index) => [el, index]);
-  stabilizedThis.sort((a, b) => {
-    const order = comparator(a[0], b[0]);
-    if (order !== 0) return order;
-    return a[1] - b[1];
-  });
-  return stabilizedThis.map((el) => el[0]);
-}
-
-function EnhancedTableHead(props) {
-  const { classes, order, orderBy, onRequestSort } = props;
-  const createSortHandler = (property) => (event) => {
-    onRequestSort(event, property);
-  };
-
-  return (
-    <TableHead>
-      <TableRow>
-        {columns.map((headCell) => (
-          <StyledTableCell
-            key={headCell.id}
-            align={headCell.numeric ? "right" : "left"}
-            padding={headCell.disablePadding ? "none" : "default"}
-            sortDirection={orderBy === headCell.id ? order : false}
-          >
-            <TableSortLabel
-              active={orderBy === headCell.id}
-              direction={orderBy === headCell.id ? order : "asc"}
-              onClick={createSortHandler(headCell.id)}
-            >
-              {headCell.label}
-              {orderBy === headCell.id ? (
-                <span className={classes.visuallyHidden}>
-                  {order === "desc" ? "sorted descending" : "sorted ascending"}
-                </span>
-              ) : null}
-            </TableSortLabel>
-          </StyledTableCell>
-        ))}
-      </TableRow>
-    </TableHead>
-  );
-}
-
-EnhancedTableHead.propTypes = {
-  classes: PropTypes.shape({
-    visuallyHidden: PropTypes.any,
-  }).isRequired,
-  onRequestSort: PropTypes.func.isRequired,
-  order: PropTypes.oneOf(["asc", "desc"]).isRequired,
-  orderBy: PropTypes.string.isRequired,
-};
-
 function isString(x) {
   return Object.prototype.toString.call(x) === "[object String]";
 }
+
+const getMuiTheme = (theme) =>
+  createMuiTheme({
+    overrides: {
+      MUIDataTableBodyCell: {
+        root: {
+          padding: `${theme.spacing(0.25)}px 0px ${theme.spacing(0.25)}px ${theme.spacing(1)}px`,
+        },
+      },
+    },
+  });
 
 const ZTFAlert = ({ route }) => {
   const objectId = route.id;
@@ -288,31 +104,26 @@ const ZTFAlert = ({ route }) => {
   const [jd, setJd] = useState(0);
 
   const alert_data = useSelector((state) => state.alert_data);
+
+  const makeRow = (alert) => {
+    return {
+      "candid": alert?.candid,
+      "jd": alert?.candidate.jd,
+      "fid": alert?.candidate.fid,
+      "mag": alert?.candidate.magpsf,
+      "emag": alert?.candidate.sigmapsf,
+      "rb": alert?.candidate.rb,
+      "drb": alert?.candidate.drb,
+      "isdiffpos": alert?.candidate.isdiffpos,
+      "programid": alert?.candidate.programid,
+      "alert_actions": "show thumbnails",
+    }
+  }
+
   let rows = [];
 
   if (alert_data !== null && !isString(alert_data)) {
-    rows = alert_data.map((a) =>
-      createRows(
-        a.candid,
-        a.candidate.jd,
-        a.candidate.fid,
-        a.candidate.magpsf,
-        a.candidate.sigmapsf,
-        a.candidate.rb,
-        a.candidate.drb,
-        a.candidate.isdiffpos,
-        a.candidate.programid,
-        <Button
-          size="small"
-          onClick={() => {
-            setCandid(a.candid);
-            setJd(a.candidate.jd);
-          }}
-        >
-          Show&nbsp;thumbnails
-        </Button>
-      )
-    );
+    rows = alert_data?.map((a) => makeRow(a));
   }
 
   const alert_aux_data = useSelector((state) => state.alert_aux_data);
@@ -355,25 +166,6 @@ const ZTFAlert = ({ route }) => {
   }, [dispatch, isCached, route.id, objectId]);
 
   const classes = useStyles();
-  const [order, setOrder] = React.useState("desc");
-  const [orderBy, setOrderBy] = React.useState("jd");
-  const [page, setPage] = React.useState(0);
-  const [rowsPerPage, setRowsPerPage] = React.useState(10);
-
-  const handleRequestSort = (event, property) => {
-    const isAsc = orderBy === property && order === "asc";
-    setOrder(isAsc ? "desc" : "asc");
-    setOrderBy(property);
-  };
-
-  const handleChangePage = (event, newPage) => {
-    setPage(newPage);
-  };
-
-  const handleChangeRowsPerPage = (event) => {
-    setRowsPerPage(+event.target.value);
-    setPage(0);
-  };
 
   const thumbnails = [
     {
@@ -392,6 +184,119 @@ const ZTFAlert = ({ route }) => {
       public_url: `/api/alerts/ztf/${objectId}/cutout?candid=${candid}&cutout=difference&file_format=png`,
     },
   ];
+
+  const options = {
+  selectableRows: "none"
+}
+
+const columns = [
+  {
+    name: "candid",
+    label: "candid",
+    options: {
+      filter: false,
+      sort: true,
+    }
+  },
+  {
+    name: "jd",
+    label: "JD",
+    options: {
+      filter: false,
+      sort: true,
+      customBodyRender: (value, tableMeta, updateValue) => (
+        value.toFixed(5)
+      )
+    }
+  },
+  {
+    name: "fid",
+    label: "fid",
+    options: {
+      filter: true,
+      sort: true,
+    }
+  },
+  {
+    name: "mag",
+    label: "mag",
+    options: {
+      filter: false,
+      sort: true,
+      customBodyRender: (value, tableMeta, updateValue) => (
+        value.toFixed(3)
+      )
+    }
+  },
+  {
+    name: "emag",
+    label: "e_mag",
+    options: {
+      filter: false,
+      sort: true,
+      customBodyRender: (value, tableMeta, updateValue) => (
+        value.toFixed(3)
+      )
+    }
+  },
+  {
+    name: "rb",
+    label: "rb",
+    options: {
+      filter: false,
+      sort: true,
+      customBodyRender: (value, tableMeta, updateValue) => (
+        value.toFixed(5)
+      )
+    }
+  },
+  {
+    name: "drb",
+    label: "drb",
+    options: {
+      filter: false,
+      sort: true,
+      customBodyRender: (value, tableMeta, updateValue) => (
+        value.toFixed(5)
+      )
+    }
+  },
+  {
+    name: "isdiffpos",
+    label: "isdiffpos",
+    options: {
+      filter: true,
+      sort: true,
+    }
+  },
+  {
+    name: "programid",
+    label: "programid",
+    options: {
+      filter: true,
+      sort: true,
+    }
+  },
+  {
+    name: "alert_actions",
+    label: "actions",
+    options: {
+      filter: false,
+      sort: false,
+      customBodyRender: (value, tableMeta, updateValue) => (
+        <Button
+          size="small"
+          onClick={() => {
+            setCandid(tableMeta.rowData[0]);
+            setJd(tableMeta.rowData[1]);
+          }}
+        >
+          Show&nbsp;thumbnails
+        </Button>
+      )
+    }
+  },
+];
 
   if (alert_data === null) {
     return <div><CircularProgress color="secondary" /></div>;
@@ -420,8 +325,6 @@ const ZTFAlert = ({ route }) => {
             startIcon={<SaveIcon />}
             // todo: save as a source to one of my programs button
             // onClick={() => dispatch(Actions.saveSource(group_id, objectId, candid))}
-            // fixme: once that is implemented
-            style={{ display: "none" }}
           >
             Save as a Source
           </Button>
@@ -444,7 +347,7 @@ const ZTFAlert = ({ route }) => {
             <Grid container spacing={2}>
               <Grid item xs={12} lg={6}>
                 <Suspense fallback={<div>Loading plot...</div>}>
-                  <VegaPlot
+                  <VegaPlotZTFAlert
                     dataUrl={`/api/alerts/ztf/${objectId}/aux`}
                     jd={jd}
                   />
@@ -474,51 +377,14 @@ const ZTFAlert = ({ route }) => {
         </Accordion>
 
         <Paper className={classes.root}>
-          <TableContainer className={classes.container}>
-            <Table stickyHeader size="small" aria-label="sticky table">
-              <EnhancedTableHead
-                classes={classes}
-                order={order}
-                orderBy={orderBy}
-                onRequestSort={handleRequestSort}
-              />
-              <TableBody>
-                {stableSort(rows, getComparator(order, orderBy))
-                  .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
-                  .map((row) => (
-                    <TableRow
-                      hover
-                      role="checkbox"
-                      tabIndex={-1}
-                      key={row.name}
-                    >
-                      {columns.map((column) => {
-                        const value = row[column.id];
-                        return (
-                          <TableCell
-                            key={column.id}
-                            align={column.numeric ? "right" : "left"}
-                          >
-                            {column.format && typeof value === "number"
-                              ? column.format(value)
-                              : value}
-                          </TableCell>
-                        );
-                      })}
-                    </TableRow>
-                  ))}
-              </TableBody>
-            </Table>
-          </TableContainer>
-          <TablePagination
-            rowsPerPageOptions={[10, 25, 100]}
-            component="div"
-            count={rows.length}
-            rowsPerPage={rowsPerPage}
-            page={page}
-            onChangePage={handleChangePage}
-            onChangeRowsPerPage={handleChangeRowsPerPage}
-          />
+          <MuiThemeProvider theme={getMuiTheme(theme)}>
+            <MUIDataTable
+              title={"Alerts"}
+              data={rows}
+              columns={columns}
+              options={options}
+            />
+          </MuiThemeProvider>
         </Paper>
 
         <Accordion

--- a/extensions/skyportal/static/js/components/ZTFAlert.jsx
+++ b/extensions/skyportal/static/js/components/ZTFAlert.jsx
@@ -43,7 +43,7 @@ const useStyles = makeStyles((theme) => ({
   itemPaddingBottom: {
     paddingBottom: "0.5rem",
   },
-  saveCandidateButton: {
+  saveAlertButton: {
     margin: "0.5rem 0",
   },
   image: {
@@ -141,8 +141,6 @@ const ZTFAlert = ({ route }) => {
         throw new Error(`JSON decoding error: ${error}`);
       }
 
-      console.log(json);
-
       if (json.status === "success") {
         setsavedSource(true)
       }
@@ -153,6 +151,10 @@ const ZTFAlert = ({ route }) => {
 
   const userAccessibleGroups = useSelector(
     (state) => state.groups.userAccessible
+  );
+
+  const userAccessibleGroupIds = useSelector(
+    (state) => state.groups.userAccessible?.map((a) => a.id)
   );
 
   const theme = useTheme();
@@ -264,6 +266,10 @@ const ZTFAlert = ({ route }) => {
   const options = {
     selectableRows: "none",
     elevation: 1,
+    sortOrder: {
+      name: "jd",
+      direction: "desc"
+    },
   }
 
 const columns = [
@@ -282,7 +288,6 @@ const columns = [
     options: {
       filter: false,
       sort: true,
-      sortDirection: 'desc',
       sortDescFirst: true,
       customBodyRender: (value, tableMeta, updateValue) => (
         value.toFixed(5)
@@ -426,9 +431,9 @@ const columns = [
                   label="NOT SAVED"
                 />
                 <br />
-                <div className={classes.saveCandidateButton}>
+                <div className={classes.saveAlertButton}>
                   <SaveAlertButton
-                    candidate={{id: objectId, passing_group_ids: [1]}}
+                    alert={{id: objectId, group_ids: userAccessibleGroupIds}}
                     userGroups={userAccessibleGroups}
                   />
                 </div>

--- a/extensions/skyportal/static/js/ducks/alert.js
+++ b/extensions/skyportal/static/js/ducks/alert.js
@@ -1,6 +1,5 @@
 import * as API from "../API";
 import store from "../store";
-import {ADD_FILTER_VERSION} from "./kowalski_filter";
 
 export const FETCH_ALERT = "skyportal/FETCH_ALERT";
 export const FETCH_ALERT_OK = "skyportal/FETCH_ALERT_OK";

--- a/extensions/skyportal/static/js/ducks/alert.js
+++ b/extensions/skyportal/static/js/ducks/alert.js
@@ -1,5 +1,6 @@
 import * as API from "../API";
 import store from "../store";
+import {ADD_FILTER_VERSION} from "./kowalski_filter";
 
 export const FETCH_ALERT = "skyportal/FETCH_ALERT";
 export const FETCH_ALERT_OK = "skyportal/FETCH_ALERT_OK";
@@ -11,12 +12,19 @@ export const FETCH_AUX_OK = "skyportal/FETCH_AUX_OK";
 export const FETCH_AUX_ERROR = "skyportal/FETCH_AUX_ERROR";
 export const FETCH_AUX_FAIL = "skyportal/FETCH_AUX_FAIL";
 
+export const SAVE_ALERT = "skyportal/SAVE_ALERT";
+export const SAVE_ALERT_OK = "skyportal/SAVE_ALERT_OK";
+
 export function fetchAlertData(id) {
   return API.GET(`/api/alerts/ztf/${id}`, FETCH_ALERT);
 }
 
 export const fetchAuxData = (id) =>
   API.GET(`/api/alerts/ztf/${id}/aux`, FETCH_AUX);
+
+export function saveAlertAsSource({ id, payload }) {
+  return API.POST(`/api/alerts/ztf/${id}`, SAVE_ALERT, payload);
+}
 
 const alertDataReducer = (state = null, action) => {
   switch (action.type) {

--- a/extensions/skyportal/static/js/ducks/kowalski_filter.js
+++ b/extensions/skyportal/static/js/ducks/kowalski_filter.js
@@ -28,11 +28,15 @@ export function fetchFilterVersion(id) {
 }
 
 export function addFilterVersion({ filter_id, pipeline }) {
-  return API.POST(`/api/filters/${filter_id}/v`, ADD_FILTER_VERSION, { pipeline });
+  return API.POST(`/api/filters/${filter_id}/v`, ADD_FILTER_VERSION, {
+    pipeline,
+  });
 }
 
 export function editActiveFilterVersion({ filter_id, active }) {
-  return API.PATCH(`/api/filters/${filter_id}/v`, EDIT_ACTIVE_FILTER_VERSION, { active });
+  return API.PATCH(`/api/filters/${filter_id}/v`, EDIT_ACTIVE_FILTER_VERSION, {
+    active,
+  });
 }
 
 export function editActiveFidFilterVersion({ filter_id, active_fid }) {

--- a/fritz
+++ b/fritz
@@ -483,10 +483,10 @@ if __name__ == "__main__":
         "--init", action="store_true", help="Initialize Fritz"
     )
     parsers["run"].add_argument(
-        "--repo", type=str, default="origin", help="Remote repository to pull from"
+        "--repo", type=str, default="origin", help="Remote repository to pull from at init"
     )
     parsers["run"].add_argument(
-        "--branch", type=str, default="master", help="Branch on the remote repository"
+        "--branch", type=str, default="master", help="Branch on the remote repository at init"
     )
     parsers["run"].add_argument(
         "--dev", action="store_true", help="Run Fritz in dev mode"

--- a/fritz
+++ b/fritz
@@ -483,6 +483,12 @@ if __name__ == "__main__":
         "--init", action="store_true", help="Initialize Fritz"
     )
     parsers["run"].add_argument(
+        "--repo", type=str, default="origin", help="Remote repository to pull from"
+    )
+    parsers["run"].add_argument(
+        "--branch", type=str, default="master", help="Branch on the remote repository"
+    )
+    parsers["run"].add_argument(
         "--dev", action="store_true", help="Run Fritz in dev mode"
     )
     parsers["run"].add_argument(


### PR DESCRIPTION
In this PR:

- `extensions/skyportal/skyportal/handlers/api/alert.py`:
  - new endpoint `ZTFAlertHandler.post` to save ZTF alerts as sources by their `objectId`, e.g. `api('POST', '<fritz_instance_location>/api/alerts/ztf/<objectId>'), {"candid": <candid>, "group_ids": <list of group ids>}`. Under the hood, F pulls the required data from K, massages them, and posts to SP's `/api/sources`, `/api/photometry`, and `/api/thumbnail`. If `candid` is not provided, metadata and thumbnails will be pulled from the latest alert/candid. If no list of group_ids is provided, the object will be saved to all user's groups
  - async api calls to Kowalski using `tornado.httpclient` instead of `requests`
- `extensions/skyportal/static/js/components/ZTFAlert.jsx`
  - Re-skin that makes the page look a lot more like the Source and Candidate pages
  - Replaced MUI table with MUI datatable to display the alerts
  - A button to save alerts as sources
- `extensions/skyportal/static/js/components/SaveAlertButton.jsx`
  - Mostly a copy-paste of `SaveCandidateButton.jsx` with a couple modifications necessary here
- fix linting in `extensions/skyportal/static/js/components/Filter.jsx`

![ztf-alert-03](https://user-images.githubusercontent.com/7557205/94615973-7d293a00-025d-11eb-99e7-b9c1a619ee96.gif)
