### PR TITLE
Fix subtle bug in /api/ztf/<objectId>.POST

### DIFF
--- a/extensions/skyportal/skyportal/handlers/api/alert.py
+++ b/extensions/skyportal/skyportal/handlers/api/alert.py
@@ -374,8 +374,7 @@ class ZTFAlertHandler(BaseHandler):
             w = df["candid"] == str(candid)
 
             if candid is None or sum(w) == 0:
-                candids = {int(can) for can in df["candid"] if not pd.isnull(can)}
-                candid = max(candids)
+                candid = int(latest_alert_data["candidate"]["candid"])
                 alert = df.loc[df["candid"] == str(candid)].to_dict(orient="records")[0]
             else:
                 alert = df.loc[w].to_dict(orient="records")[0]


### PR DESCRIPTION
This fixes a bug in a situation like this:
- user has access to `stream_id`'s 1 and 2
- new alerts come in from `stream_id` 3 that have a 3-sigma detection in `prv_candidates` that came after the last alert the user has access to
- need to grab the `candid` of that last alert, and not the max of all candids (the 3-sigma detection does not come with thumbnails)