### PR TITLE
TNS cross-match data

### DIFF
--- a/extensions/skyportal/skyportal/handlers/api/alert.py
+++ b/extensions/skyportal/skyportal/handlers/api/alert.py
@@ -998,7 +998,6 @@ class ZTFAlertCutoutHandler(ZTFAlertHandler):
                 img_norm = norm(img)
                 vmin, vmax = normalizer.get_limits(img_norm)
                 ax.imshow(img_norm, cmap=cmap, origin='lower', vmin=vmin, vmax=vmax)
-                # ax.hist(norm(img))
                 plt.savefig(buff, dpi=42)
                 buff.seek(0)
                 plt.close('all')

--- a/extensions/skyportal/skyportal/handlers/api/alert.py
+++ b/extensions/skyportal/skyportal/handlers/api/alert.py
@@ -1,6 +1,5 @@
 from astropy.io import fits
 from astropy.visualization import (
-    AsymmetricPercentileInterval,
     MinMaxInterval,
     AsymmetricPercentileInterval,
     ZScaleInterval,

--- a/fritz
+++ b/fritz
@@ -179,7 +179,6 @@ def build(args):
             "--git-dir=.git",
             "log",
             "--no-merges",
-            "--first-parent",
             "--pretty=format:[%cI %h %cE] %s",
             "-1000"
         ],


### PR DESCRIPTION
In this PR:

- In `/api/alerts/ztf/<oid>/aux`, run a cone search on the TNS collection on Kowalski and report the results as a part of the `cross_matches` field.

![tns-x-match](https://user-images.githubusercontent.com/7557205/97932512-0df3a980-1d25-11eb-9e3c-3d9a44d7b0ca.gif)
