### PR TITLE
Replace nans with median in thumbnails

### DIFF
--- a/extensions/skyportal/skyportal/handlers/api/alert.py
+++ b/extensions/skyportal/skyportal/handlers/api/alert.py
@@ -61,9 +61,11 @@ def make_thumbnail(a, ttype, ztftype):
     ax.set_axis_off()
     fig.add_axes(ax)
 
-    # remove nans:
+    # replace nans with median:
     img = np.array(data_flipped_y)
-    img = np.nan_to_num(img)
+    if np.isnan(img).any():
+        median = float(np.nanmean(img.flatten()))
+        img = np.nan_to_num(img, nan=median)
 
     norm = ImageNormalize(
         img,
@@ -1032,9 +1034,11 @@ class ZTFAlertCutoutHandler(ZTFAlertHandler):
                 fig.subplots_adjust(0, 0, 1, 1)
                 ax.set_axis_off()
 
-                # remove nans:
+                # replace nans with median:
                 img = np.array(data_flipped_y)
-                img = np.nan_to_num(img)
+                if np.isnan(img).any():
+                    median = float(np.nanmean(img.flatten()))
+                    img = np.nan_to_num(img, nan=median)
                 norm = ImageNormalize(
                     img,
                     stretch=stretcher

--- a/fritz.defaults.yaml
+++ b/fritz.defaults.yaml
@@ -274,15 +274,15 @@ skyportal:
 
   notifications:
     enabled: True
-   
+
   smtp:
     from_email:
-    password: 
-    host: 
+    password:
+    host:
     port:
   # This value needs to be either "sendgrid" or "smtp" (without quotes)
   email_service: sendgrid
- 
+
 kowalski:
   server:
     name: "Kowalski"


### PR DESCRIPTION
...instead of zeros as is currently done.

Example:

After:
![image](https://user-images.githubusercontent.com/7557205/99843853-073ba380-2b27-11eb-9dc1-d0eacc92ff37.png)

Before:
![image](https://user-images.githubusercontent.com/7557205/99843886-14589280-2b27-11eb-8b72-42fbd8e97b31.png)
