### PR TITLE
Remove dubiously large values in thumbnails

### DIFF
--- a/extensions/skyportal/skyportal/handlers/api/alert.py
+++ b/extensions/skyportal/skyportal/handlers/api/alert.py
@@ -63,6 +63,10 @@ def make_thumbnail(a, ttype, ztftype):
 
     # replace nans with median:
     img = np.array(data_flipped_y)
+    # replace dubiously large values
+    xl = np.greater(np.abs(img), 1e20, where=~np.isnan(img))
+    if img[xl].any():
+        img[xl] = np.nan
     if np.isnan(img).any():
         median = float(np.nanmean(img.flatten()))
         img = np.nan_to_num(img, nan=median)
@@ -1036,6 +1040,10 @@ class ZTFAlertCutoutHandler(ZTFAlertHandler):
 
                 # replace nans with median:
                 img = np.array(data_flipped_y)
+                # replace dubiously large values
+                xl = np.greater(np.abs(img), 1e20, where=~np.isnan(img))
+                if img[xl].any():
+                    img[xl] = np.nan
                 if np.isnan(img).any():
                     median = float(np.nanmean(img.flatten()))
                     img = np.nan_to_num(img, nan=median)


### PR DESCRIPTION
On the example of ZTF20actodrq:

After:
![image](https://user-images.githubusercontent.com/7557205/100661938-1251b900-3309-11eb-9aeb-c55cff1dea07.png)

Before:
![image](https://user-images.githubusercontent.com/7557205/100661967-1ed61180-3309-11eb-88c2-886ac6a8e3ff.png)
