### PR TITLE
update git remote command to use correct repo

### DIFF
--- a/doc/developer.md
+++ b/doc/developer.md
@@ -14,7 +14,7 @@ To prepare, you should:
 
   ```sh
   git clone git@github.com:yourname/fritz
-  git remote add upstream git@github.com:fritz/fritz
+  git remote add upstream git@github.com:fritz-marshal/fritz
   ```
 
 Then, for each feature you wish to contribute, create a pull request:


### PR DESCRIPTION
Fixed minor typo in Fritz documentation on Developer Guidelines page that specified the incorrect upstream repo.