### PR TITLE
Improve the ZTF Alert page

### DIFF
--- a/extensions/skyportal/static/js/components/VegaPlotZTFAlert.jsx
+++ b/extensions/skyportal/static/js/components/VegaPlotZTFAlert.jsx
@@ -1,19 +1,19 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import embed from 'vega-embed';
+import React from "react";
+import PropTypes from "prop-types";
+import embed from "vega-embed";
+import { isMobileOnly, withOrientationChange } from "react-device-detect";
 
-
-const spec = (url, jd) => ({
+const spec = (url, jd, isPortrait) => ({
   $schema: "https://vega.github.io/schema/vega-lite/v4.json",
-  width: 500,
+  width: isMobileOnly && isPortrait ? 250 : 500,
   // width: "container",
-  height: 250,
+  height: isMobileOnly && isPortrait ? 150 : 250,
   data: {
     url,
     format: {
       type: "json",
-      property: "data.prv_candidates" // where in the JSON does the data live
-    }
+      property: "data.prv_candidates", // where in the JSON does the data live
+    },
   },
   autosize: {
     type: "fit",
@@ -27,12 +27,12 @@ const spec = (url, jd) => ({
         filterMags: {
           type: "multi",
           fields: ["fid"],
-          bind: "legend"
+          bind: "legend",
         },
         grid: {
           type: "interval",
-          bind: "scales"
-        }
+          bind: "scales",
+        },
       },
       mark: {
         type: "point",
@@ -41,7 +41,11 @@ const spec = (url, jd) => ({
         size: 30,
       },
       transform: [
-        { calculate: "join([format(datum.magpsf, '.2f'), ' ± ', format(datum.sigmapsf, '.2f'), ' (ab)'], '')", as: "magAndErr" }
+        {
+          calculate:
+            "join([format(datum.magpsf, '.2f'), ' ± ', format(datum.sigmapsf, '.2f'), ' (ab)'], '')",
+          as: "magAndErr",
+        },
       ],
       encoding: {
         x: {
@@ -56,18 +60,18 @@ const spec = (url, jd) => ({
           type: "quantitative",
           scale: {
             zero: false,
-            reverse: true
+            reverse: true,
           },
           axis: {
-            title: "mag"
-          }
+            title: "mag",
+          },
         },
         color: {
           field: "fid",
           type: "nominal",
           scale: {
             domain: [1, 2, 3],
-            range: ["#28a745", "#dc3545", "#f3dc11"]
+            range: ["#28a745", "#dc3545", "#f3dc11"],
           },
         },
         tooltip: [
@@ -75,13 +79,13 @@ const spec = (url, jd) => ({
           { field: "magAndErr", title: "mag", type: "nominal" },
           { field: "fid", type: "ordinal" },
           { field: "jd", type: "quantitative" },
-          { field: "diffmaglim", type: "quantitative", format: ".2f" }
+          { field: "diffmaglim", type: "quantitative", format: ".2f" },
         ],
         opacity: {
           condition: { selection: "filterMags", value: 1 },
-          value: 0
-        }
-      }
+          value: 0,
+        },
+      },
     },
 
     // Render error bars
@@ -90,17 +94,17 @@ const spec = (url, jd) => ({
         filterErrBars: {
           type: "multi",
           fields: ["fid"],
-          bind: "legend"
-        }
+          bind: "legend",
+        },
       },
       transform: [
         { filter: "datum.magpsf != null && datum.sigmapsf != null" },
         { calculate: "datum.magpsf - datum.sigmapsf", as: "magMin" },
-        { calculate: "datum.magpsf + datum.sigmapsf", as: "magMax" }
+        { calculate: "datum.magpsf + datum.sigmapsf", as: "magMax" },
       ],
       mark: {
         type: "rule",
-        size: 0.5
+        size: 0.5,
       },
       encoding: {
         x: {
@@ -108,50 +112,48 @@ const spec = (url, jd) => ({
           type: "quantitative",
           scale: {
             zero: false,
-          }
+          },
         },
         y: {
           field: "magMin",
           type: "quantitative",
           scale: {
             zero: false,
-            reverse: true
-          }
+            reverse: true,
+          },
         },
         y2: {
           field: "magMax",
           type: "quantitative",
           scale: {
             zero: false,
-            reverse: true
-          }
+            reverse: true,
+          },
         },
         color: {
           field: "fid",
-          type: "nominal"
+          type: "nominal",
         },
         opacity: {
           condition: { selection: "filterErrBars", value: 1 },
-          value: 0
-        }
-      }
+          value: 0,
+        },
+      },
     },
 
     // Render limiting mags
     {
-      transform: [
-        { filter: "datum.magpsf == null" }
-      ],
+      transform: [{ filter: "datum.magpsf == null" }],
       selection: {
         filterLimitingMags: {
           type: "multi",
           fields: ["fid"],
-          bind: "legend"
-        }
+          bind: "legend",
+        },
       },
       mark: {
         type: "point",
-        shape: "triangle-down"
+        shape: "triangle-down",
       },
       encoding: {
         x: {
@@ -159,26 +161,26 @@ const spec = (url, jd) => ({
           type: "quantitative",
           scale: {
             zero: false,
-          }
+          },
         },
         y: {
           field: "diffmaglim",
-          type: "quantitative"
+          type: "quantitative",
         },
         color: {
           field: "fid",
-          type: "nominal"
+          type: "nominal",
         },
         tooltip: [
           { field: "fid", type: "ordinal" },
           { field: "jd", type: "quantitative" },
-          { field: "diffmaglim", type: "quantitative", format: ".2f" }
+          { field: "diffmaglim", type: "quantitative", format: ".2f" },
         ],
         opacity: {
           condition: { selection: "filterLimitingMags", value: 0.3 },
-          value: 0
-        }
-      }
+          value: 0,
+        },
+      },
     },
 
     // render selected candid date
@@ -188,29 +190,26 @@ const spec = (url, jd) => ({
       encoding: {
         x: {
           datum: jd,
-          type: "quantitative"
-        }
-      }
-    }
-  ]
+          type: "quantitative",
+        },
+      },
+    },
+  ],
 });
 
-
-const VegaPlot = ({ dataUrl, jd }) => (
+const VegaPlot = withOrientationChange(({ dataUrl, jd, isPortrait }) => (
   <div
-    ref={
-          (node) => {
-            embed(node, spec(dataUrl, jd), {
-              actions: false
-            });
-          }
-        }
+    ref={(node) => {
+      embed(node, spec(dataUrl, jd, isPortrait), {
+        actions: false,
+      });
+    }}
   />
-);
+));
 
 VegaPlot.propTypes = {
   dataUrl: PropTypes.string.isRequired,
-  jd: PropTypes.number.isRequired
+  jd: PropTypes.number.isRequired,
 };
 
 export default VegaPlot;

--- a/extensions/skyportal/static/js/components/ZTFAlert.jsx
+++ b/extensions/skyportal/static/js/components/ZTFAlert.jsx
@@ -100,6 +100,15 @@ const useStyles = makeStyles((theme) => ({
     display: "inline-block",
     verticalAlign: "super",
   },
+  sourceInfo: {
+    display: "flex",
+    flexFlow: "row wrap",
+    alignItems: "center",
+  },
+  position: {
+    fontWeight: "bold",
+    fontSize: "110%",
+  },
 }));
 
 function isString(x) {
@@ -153,7 +162,7 @@ const ZTFAlert = ({ route }) => {
       if (json.status === "success") {
         setsavedSource(true);
       }
-      setsCheckedIfSourceSaved(true)
+      setsCheckedIfSourceSaved(true);
     };
 
     if (!checkedIfSourceSaved) {
@@ -188,6 +197,11 @@ const ZTFAlert = ({ route }) => {
 
   const handlePanelXMatchChange = (panel) => (event, isExpanded) => {
     setPanelXMatchExpanded(isExpanded ? panel : false);
+  };
+
+  const [panelAlertsExpanded, setPanelAlertsExpanded] = useState(true);
+  const handlePanelAlertsExpandedChange = (panel) => (event, isExpanded) => {
+    setPanelAlertsExpanded(isExpanded ? panel : false);
   };
 
   const [candid, setCandid] = useState(0);
@@ -426,7 +440,7 @@ const ZTFAlert = ({ route }) => {
             </div>
             <div className={classes.name}>{objectId}</div>
             <br />
-            {savedSource || (loadedSourceId === objectId) ? (
+            {savedSource || loadedSourceId === objectId ? (
               <div className={classes.itemPaddingBottom}>
                 <Chip
                   size="small"
@@ -444,7 +458,11 @@ const ZTFAlert = ({ route }) => {
                 <br />
                 <div className={classes.saveAlertButton}>
                   <SaveAlertButton
-                    alert={{ id: objectId, candid: parseInt(candid), group_ids: userAccessibleGroupIds }}
+                    alert={{
+                      id: objectId,
+                      candid: parseInt(candid),
+                      group_ids: userAccessibleGroupIds,
+                    }}
                     userGroups={userAccessibleGroups}
                   />
                 </div>
@@ -456,33 +474,57 @@ const ZTFAlert = ({ route }) => {
                 &nbsp;
                 {candid}
                 <br />
-                <b>Position (J2000):</b>
-                &nbsp;
-                {alert_data.filter((a) => a.candid === candid)[0].candidate.ra},
-                &nbsp;
-                {alert_data.filter((a) => a.candid === candid)[0].candidate.dec}
-                &nbsp; (&alpha;,&delta;=
-                {ra_to_hours(
-                  alert_data.filter((a) => a.candid === candid)[0].candidate.ra
-                )}
-                , &nbsp;
-                {dec_to_dms(
-                  alert_data.filter((a) => a.candid === candid)[0].candidate.dec
-                )}
-                )
-              </>
-            )}
-            {candid > 0 && alert_data.filter((a) => a.candid === candid)[0].coordinates.b && (
-              <>
-                &nbsp; (l,b=
-                {alert_data
-                  .filter((a) => a.candid === candid)[0]
-                  .coordinates?.l?.toFixed(6)}
-                , &nbsp;
-                {alert_data
-                  .filter((a) => a.candid === candid)[0]
-                  .coordinates?.b?.toFixed(6)}
-                )
+                <div className={classes.sourceInfo}>
+                  <div>
+                    <b>Position (J2000):&nbsp; &nbsp;</b>
+                  </div>
+                  <div>
+                    <span className={classes.position}>
+                      {ra_to_hours(
+                        alert_data.filter((a) => a.candid === candid)[0]
+                          .candidate.ra,
+                        ":"
+                      )}
+                      &nbsp;
+                      {dec_to_dms(
+                        alert_data.filter((a) => a.candid === candid)[0]
+                          .candidate.dec,
+                        ":"
+                      )}
+                      &nbsp;
+                    </span>
+                  </div>
+                </div>
+                <div className={classes.sourceInfo}>
+                  <div>
+                    (&alpha;,&delta;={" "}
+                    {
+                      alert_data.filter((a) => a.candid === candid)[0].candidate
+                        .ra
+                    }
+                    , &nbsp;
+                    {
+                      alert_data.filter((a) => a.candid === candid)[0].candidate
+                        .dec
+                    }
+                    ; &nbsp;
+                  </div>
+                  {candid > 0 &&
+                    alert_data.filter((a) => a.candid === candid)[0].coordinates
+                      .b && (
+                      <div>
+                        &nbsp; l,b=
+                        {alert_data
+                          .filter((a) => a.candid === candid)[0]
+                          .coordinates?.l?.toFixed(6)}
+                        , &nbsp;
+                        {alert_data
+                          .filter((a) => a.candid === candid)[0]
+                          .coordinates?.b?.toFixed(6)}
+                        )
+                      </div>
+                    )}
+                </div>
               </>
             )}
           </div>
@@ -494,7 +536,7 @@ const ZTFAlert = ({ route }) => {
             <AccordionSummary
               expandIcon={<ExpandMoreIcon />}
               aria-controls="panel-content"
-              id="panel-header"
+              id="photometry-panel-header"
             >
               <Typography className={classes.accordionHeading}>
                 Photometry and cutouts
@@ -522,8 +564,14 @@ const ZTFAlert = ({ route }) => {
                 >
                   {candid > 0 && (
                     <ThumbnailList
-                      ra={alert_data.filter((a) => a.candid === candid)[0].candidate.ra}
-                      dec={alert_data.filter((a) => a.candid === candid)[0].candidate.dec}
+                      ra={
+                        alert_data.filter((a) => a.candid === candid)[0]
+                          .candidate.ra
+                      }
+                      dec={
+                        alert_data.filter((a) => a.candid === candid)[0]
+                          .candidate.dec
+                      }
                       thumbnails={thumbnails}
                       displayTypes={["new", "ref", "sub"]}
                       size="10rem"
@@ -534,16 +582,25 @@ const ZTFAlert = ({ route }) => {
             </AccordionDetails>
           </Accordion>
 
-          <Paper className={classes.root}>
-            <MuiThemeProvider theme={getMuiTheme(theme)}>
-              <MUIDataTable
-                title="Alerts"
-                data={rows}
-                columns={columns}
-                options={options}
-              />
-            </MuiThemeProvider>
-          </Paper>
+          <Accordion
+            expanded={panelAlertsExpanded}
+            onChange={handlePanelAlertsExpandedChange(true)}
+          >
+            <AccordionSummary
+              expandIcon={<ExpandMoreIcon />}
+              aria-controls="panel-content"
+              id="alerts-panel-header"
+            >
+              <Typography className={classes.accordionHeading}>
+                Alerts
+              </Typography>
+            </AccordionSummary>
+            <AccordionDetails className={classes.accordion_details}>
+              <MuiThemeProvider theme={getMuiTheme(theme)}>
+                <MUIDataTable data={rows} columns={columns} options={options} />
+              </MuiThemeProvider>
+            </AccordionDetails>
+          </Accordion>
 
           <Accordion
             expanded={panelXMatchExpanded}
@@ -552,7 +609,7 @@ const ZTFAlert = ({ route }) => {
             <AccordionSummary
               expandIcon={<ExpandMoreIcon />}
               aria-controls="panel-content"
-              id="panel-header"
+              id="xmatch-panel-header"
             >
               <Typography className={classes.accordionHeading}>
                 Cross-matches


### PR DESCRIPTION
- Re-style the position text to better match the source page on SP, i.e. with colon separators
- Put the Alerts table in an Accordion tab so user can just close the tab to get to the cross matches instead of scrolling (the tables can get very long on mobile since the MUI DataTable essentially flips rows and columns as its responsiveness strategy)
- Limit the size of the Vega plot for the alert when a phone in portrait mode is detected (the narrowest screen types).

![alerts](https://user-images.githubusercontent.com/17696889/108927288-fb6fe980-760d-11eb-8c9a-482b0967513e.gif)
