### PR TITLE
Enable dashboard widgets resizing

### DIFF
--- a/fritz.defaults.yaml
+++ b/fritz.defaults.yaml
@@ -177,7 +177,7 @@ skyportal:
       # 150px in height. The row height can be altered in the homepage_grid
       # section above (as well as other grid characteristics).
       WeatherWidget:
-        resizeable: false
+        resizeable: true
         layouts:
           xlg: [0, 10, 4, 1]
           lg: [0, 10, 4, 1]
@@ -188,7 +188,7 @@ skyportal:
       SourceCounts:
         props:
           sinceDaysAgo: 7
-        resizeable: false
+        resizeable: true
         layouts:
           xlg: [14, 0, 2, 1]
           lg: [10, 0, 2, 1]
@@ -197,7 +197,7 @@ skyportal:
           xs: [0, 0, 4, 1]
 
       RecentSources:
-        resizeable: false
+        resizeable: true
         layouts:
           xlg: [0, 0, 5, 3]
           lg: [0, 0, 4, 3]
@@ -206,7 +206,7 @@ skyportal:
           xs: [0, 4, 4, 3]
 
       NewsFeed:
-        resizeable: false
+        resizeable: true
         layouts:
           xlg: [10, 0, 4, 3]
           lg: [7, 0, 3, 3]
@@ -215,7 +215,7 @@ skyportal:
           xs: [0, 1, 4, 3]
 
       TopSources:
-        resizeable: false
+        resizeable: true
         layouts:
           xlg: [5, 0, 5, 3]
           lg: [4, 3, 3, 3]


### PR DESCRIPTION
Close skyportal/skyportal#1539.

Now that skyportal/skyportal#1754 has been merged, we can re-enable resizing for dashboard widgets and have it work properly.