### PR TITLE
Refactor fritz utility to use python-fire

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -15,6 +15,7 @@ jobs:
   build-publish-deploy:
     name: Setup, Build, Publish
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/cache@v2

--- a/.github/workflows/build-test-doc_upload.yaml
+++ b/.github/workflows/build-test-doc_upload.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   build-test-doc:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
 
     - uses: actions/checkout@v2

--- a/.github/workflows/build-test-doc_upload.yaml
+++ b/.github/workflows/build-test-doc_upload.yaml
@@ -33,7 +33,7 @@ jobs:
         pip install wheel
         pip install -r skyportal/baselayer/requirements.txt
         pip install -r skyportal/requirements.txt
-        ./fritz doc
+        ./fritz doc --yes
 
     - name: Install SSH Client 🔑
       if: github.ref == 'refs/heads/master'

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Build and spin up
         run: |
           cp kowalski/docker-compose.defaults.yaml kowalski/docker-compose.yaml
-          ./fritz run --init --dev
+          ./fritz run --init
 
       - name: Run integration tests
         run: |

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -22,17 +22,17 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install "wheel>=0.36"
-          pip install -r requirements.txt
+          python -m pip install "wheel>=0.36"
+          python -m pip install -r requirements.txt
           ./fritz develop
 
       - name: Set up configs
         run: |
           cp fritz.defaults.yaml fritz.yaml
+          cp kowalski/docker-compose.defaults.yaml kowalski/docker-compose.yaml
 
       - name: Build and spin up
         run: |
-          cp kowalski/docker-compose.defaults.yaml kowalski/docker-compose.yaml
           ./fritz run --init
 
       - name: Run integration tests

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -9,6 +9,7 @@ on:
 jobs:
   test-integration:
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v2
         with:

--- a/fritz
+++ b/fritz
@@ -11,7 +11,7 @@ import sys
 import time
 import yaml
 
-from tools.check_environment import deps_ok
+from tools.check_environment import dependencies_ok
 
 sys.path.insert(0, "skyportal")
 
@@ -124,6 +124,7 @@ def check_config(cfg="fritz.defaults.yaml", yes=False, **kwargs):
     p = subprocess.run(command, stdout=subprocess.PIPE)
     gateway_ip = p.stdout.decode("utf-8").strip()
     config["kowalski"]["skyportal"]["host"] = gateway_ip
+    config["skyportal"]["kowalski"]["host"] = gateway_ip
 
     # strip down, adjust, and copy over to Kowalski and SkyPortal
     config_kowalski = {"kowalski": config["kowalski"]}  # don't need the SP stuff
@@ -255,7 +256,7 @@ def build(args):
         update(args)
 
     # check environment
-    env_ok = deps_ok()
+    env_ok = dependencies_ok()
     if not env_ok:
         raise RuntimeError("Halting because of unsatisfied system dependencies")
 

--- a/fritz
+++ b/fritz
@@ -400,7 +400,7 @@ class Fritz:
         """Install tools for developing Fritz"""
         subprocess.run(["pre-commit", "install"])
 
-    def doc(self, yes: bool = True, upload: bool = False):
+    def doc(self, yes: bool = False, upload: bool = False):
         """Build the documentation
 
         :param yes: agree to all potentially asked questions

--- a/fritz
+++ b/fritz
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-import argparse
 import datetime
 from distutils.dir_util import copy_tree
 import json
@@ -16,303 +15,578 @@ from tools.check_environment import dependencies_ok
 sys.path.insert(0, "skyportal")
 
 
-def generate_kowalski_token(
-    user_id, jwt_secret, jwt_algorithm="HS256", jwt_exp_delta_seconds=30 * 86400 * 12
-):
-    """
-    Generate a token for SkyPortal to access Kowalski
-    """
-    import jwt
+class Fritz:
+    # def __init__(self):
+    #     pass
 
-    jwt_config = {
-        "user_id": user_id,
-        "JWT_SECRET": jwt_secret,
-        "JWT_ALGORITHM": jwt_algorithm,
-        "JWT_EXP_DELTA_SECONDS": jwt_exp_delta_seconds,
-    }
+    @staticmethod
+    def _patch_skyportal():
+        """Make fritz-specific file modifications to SkyPortal."""
+        print("Applying fritz-specific patches to SkyPortal")
 
-    payload = {
-        "user_id": jwt_config["user_id"],
-        "exp": datetime.datetime.utcnow()
-        + datetime.timedelta(seconds=jwt_config["JWT_EXP_DELTA_SECONDS"]),
-    }
-    jwt_token = jwt.encode(
-        payload, jwt_config["JWT_SECRET"], jwt_config["JWT_ALGORITHM"]
-    )
+        p = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"], stdout=subprocess.PIPE
+        )
+        git_hash = p.stdout.decode("utf-8").strip()
 
-    return jwt_token
+        # add Fritz-specific SP extensions
+        copy_tree("extensions/skyportal/", "skyportal/")
 
+        # Add fritz and SkyPortal git version to skyportal/__init__.py
+        from skyportal import __version__
 
-def get_skyportal_token():
-    """
-    Get admin token for Kowalski to access SkyPortal
-    """
-    result = subprocess.run(
-        [
+        init_file = "skyportal/skyportal/__init__.py"
+        with open(init_file, "r") as f:
+            init = f.readlines()
+        out = []
+        for line in init:
+            if line.startswith("__version__ = "):
+                __version__ = "+".join(
+                    [v for v in __version__.split("+") if not v.startswith("fritz")]
+                )
+                line = f'__version__ = "{__version__}+fritz.{git_hash}"\n'
+            out.append(line)
+        with open(init_file, "wb") as f:
+            f.write("".join(out).encode("utf-8"))
+
+        # get the git log for SP and add it to the SP distro
+        p = subprocess.run(
+            [
+                "git",
+                "--git-dir=.git",
+                "log",
+                "--no-merges",
+                "--pretty=format:[%cI %h %cE] %s",
+                "-1000",
+            ],
+            capture_output=True,
+            universal_newlines=True,
+            cwd="skyportal",
+        )
+        out = p.stdout
+        with open("skyportal/data/gitlog.txt", "w") as spgl:
+            spgl.write(out)
+
+        # add Fritz-specific dependencies for SP
+        # js
+        with open("extensions/skyportal/package.fritz.json", "r") as f:
+            fritz_pkg = json.load(f)
+        with open("skyportal/package.json", "r") as f:
+            skyportal_pkg = json.load(f)
+
+        skyportal_pkg["dependencies"] = {
+            **skyportal_pkg["dependencies"],
+            **fritz_pkg["dependencies"],
+        }
+        with open("skyportal/package.json", "w") as f:
+            json.dump(skyportal_pkg, f, indent=2)
+
+        # python
+        with open(".requirements/ext.txt", "r") as f:
+            ext_req = f.readlines()
+        with open("skyportal/requirements.txt", "r") as f:
+            skyportal_req = f.readlines()
+        with open("skyportal/requirements.txt", "w") as f:
+            f.writelines(skyportal_req)
+            for line in ext_req:
+                if line not in skyportal_req:
+                    f.write(line)
+
+        # The skyportal .dockerignore includes config.yaml, but we would like
+        # to add that file; we therefore overwrite the .dockerignore
+        with open("skyportal/.dockerignore", "w") as f:
+            f.write(".*\n")
+
+    @staticmethod
+    def _check_config_exists(cfg="fritz.defaults.yaml", yes=False):
+        c = cfg.replace(".defaults", "")
+        if not Path(c).exists():
+            cd = (
+                input(
+                    f"{c} does not exist, do you want to use {cfg} (not recommended)? [y/N] "
+                )
+                if not yes
+                else "y"
+            )
+            if cd.lower() == "y":
+                subprocess.run(["cp", f"{cfg}", f"{c}"], check=True)
+            else:
+                raise IOError(f"{c} does not exist, aborting")
+
+    @classmethod
+    def _check_config(cls, cfg="fritz.defaults.yaml", yes=False):
+        """
+        Check if config exists, generate a K token for SP, adjust cfg and distribute to K and SP
+        """
+        c = cfg.replace(".defaults", "")
+        cls._check_config_exists(cfg=cfg, yes=yes)
+
+        # generate a token for SkyPortal to talk to Kowalski
+        with open(c) as config_yaml:
+            config = yaml.load(config_yaml, Loader=yaml.FullLoader)
+
+        kowalski_token = cls._generate_kowalski_token(
+            user_id=config["kowalski"]["server"]["admin_username"],
+            jwt_secret=config["kowalski"]["server"]["JWT_SECRET_KEY"],
+            jwt_algorithm=config["kowalski"]["server"]["JWT_ALGORITHM"],
+            jwt_exp_delta_seconds=int(
+                config["kowalski"]["server"]["JWT_EXP_DELTA_SECONDS"]
+            ),
+        )
+
+        config["skyportal"]["app"]["kowalski"]["token"] = kowalski_token
+
+        # get Docker gateway IP
+        command = [
             "docker",
-            "exec",
-            "-i",
-            "skyportal_web_1",
-            "/bin/bash",
-            "-c",
-            "cat /skyportal/.tokens.yaml",
-        ],
-        cwd="skyportal",
-        capture_output=True,
-        universal_newlines=True,
-    )
-    token = result.stdout.split()[-1]
+            "network",
+            "inspect",
+            "bridge",
+            '--format={{index .IPAM.Config 0 "Gateway"}}',
+        ]
+        p = subprocess.run(command, stdout=subprocess.PIPE)
+        gateway_ip = p.stdout.decode("utf-8").strip()
+        config["kowalski"]["skyportal"]["host"] = gateway_ip
+        config["skyportal"]["app"]["kowalski"]["host"] = gateway_ip
 
-    if len(token) != 36:
-        raise RuntimeError("Failed to get a SkyPortal token for Kowalski")
+        # strip down, adjust, and copy over to Kowalski and SkyPortal
+        config_kowalski = {"kowalski": config["kowalski"]}  # don't need the SP stuff
+        with open("kowalski/config.yaml", "w") as config_yaml:
+            yaml.dump(config_kowalski, config_yaml)
 
-    return token
+        # Docker-specific SkyPortal stuff:
+        config["skyportal"]["database"]["host"] = "db"
+        config["skyportal"]["server"]["url"] = "http://localhost:5000"
+        config_skyportal = config["skyportal"]  # don't need the K stuff
+        with open("skyportal/config.yaml", "w") as config_yaml:
+            yaml.dump(config_skyportal, config_yaml)
 
+        # update fritz.yaml:
+        with open(c, "w") as config_yaml:
+            yaml.dump(config, config_yaml)
 
-def skyportal_api(method, endpoint, token, data=None):
-    headers = {"Authorization": f"token {token}"}
-    response = requests.request(method, endpoint, json=data, headers=headers)
-    return response
+    @staticmethod
+    def _skyportal_api(method, endpoint, token, data=None):
+        headers = {"Authorization": f"token {token}"}
+        response = requests.request(method, endpoint, json=data, headers=headers)
+        return response
 
+    @staticmethod
+    def _generate_kowalski_token(
+        user_id: str,
+        jwt_secret: str,
+        jwt_algorithm: str = "HS256",
+        jwt_exp_delta_seconds: int = 30 * 86400 * 12,
+    ):
+        """
+        Generate a token for SkyPortal to access Kowalski
+        """
+        import jwt
 
-def check_config_exists(cfg="fritz.defaults.yaml", yes=False):
-    c = cfg.replace(".defaults", "")
-    if not Path(c).exists():
-        cd = (
+        jwt_config = {
+            "user_id": user_id,
+            "JWT_SECRET": jwt_secret,
+            "JWT_ALGORITHM": jwt_algorithm,
+            "JWT_EXP_DELTA_SECONDS": jwt_exp_delta_seconds,
+        }
+
+        payload = {
+            "user_id": jwt_config["user_id"],
+            "exp": (
+                datetime.datetime.utcnow()
+                + datetime.timedelta(seconds=jwt_config["JWT_EXP_DELTA_SECONDS"])
+            ),
+        }
+        jwt_token = jwt.encode(
+            payload, jwt_config["JWT_SECRET"], jwt_config["JWT_ALGORITHM"]
+        )
+
+        return jwt_token
+
+    @staticmethod
+    def _get_skyportal_token():
+        """Get admin token for Kowalski to access SkyPortal"""
+        result = subprocess.run(
+            [
+                "docker",
+                "exec",
+                "-i",
+                "skyportal_web_1",
+                "/bin/bash",
+                "-c",
+                "cat /skyportal/.tokens.yaml",
+            ],
+            cwd="skyportal",
+            capture_output=True,
+            universal_newlines=True,
+        )
+        token = result.stdout.split()[-1]
+
+        if len(token) != 36:
+            raise RuntimeError("Failed to get a SkyPortal token for Kowalski")
+
+        return token
+
+    def build(
+        self,
+        init: bool = False,
+        repo: str = "origin",
+        branch: str = "master",
+        traefik: bool = False,
+        no_kowalski: bool = False,
+        update: bool = True,
+        skyportal_tag: str = "skyportal/web:latest",
+        yes: bool = False,
+    ):
+        """Build Fritz
+
+        :param init: Initialize before updating Fritz
+        :param repo: Remote repository to pull from
+        :param branch: Branch on the remote repository
+        :param traefik: Build Fritz to run behind Traefik
+        :param no_kowalski: Do not build images for Kowalski
+        :param update: pull <repo>/<branch>, autostash SP and update submodules
+        :param skyportal_tag: Tag to apply to SkyPortal docker image
+        :param yes: agree with all potentially asked questions
+        """
+        if update:
+            self.update(init=init, repo=repo, branch=branch)
+
+        # check environment
+        env_ok = dependencies_ok()
+        if not env_ok:
+            raise RuntimeError("Halting because of unsatisfied system dependencies")
+
+        if not no_kowalski:
+            # install Kowalski's deps:
+            c = ["pip", "install", "-r", "requirements.txt"]
+            subprocess.run(c, cwd="kowalski", check=True)
+
+        # check config
+        self._check_config(cfg="fritz.defaults.yaml", yes=yes)
+
+        # load config
+        with open("fritz.yaml") as fritz_config_yaml:
+            fritz_config = yaml.load(fritz_config_yaml, Loader=yaml.FullLoader)
+
+        self._patch_skyportal()
+
+        # adjust F-specific docker-compose.yaml for SP
+        with open("skyportal/docker-compose.skyportal.yaml") as docker_compose_yaml:
+            docker_compose = yaml.load(docker_compose_yaml, Loader=yaml.FullLoader)
+        # fix absolute paths in docker-compose.skyportal.yaml
+        for vi, volume in enumerate(docker_compose["services"]["web"]["volumes"]):
+            docker_compose["services"]["web"]["volumes"][vi] = volume.replace(
+                "${PWD}", str(Path(__file__).parent.absolute())
+            )
+        if traefik:
+            # fix host for Traefik
+            docker_compose["services"]["web"]["labels"][2] = docker_compose["services"][
+                "web"
+            ]["labels"][2].replace(
+                "<host>", fritz_config["skyportal"]["server"]["host"]
+            )
+        else:
+            # not running behind Traefik? then publish port 5000 on host
+            port = fritz_config["skyportal"]["server"].get("port", 5000)
+            if port is None:
+                port = 5000
+            docker_compose["services"]["web"]["ports"] = [f"{port}:{port}"]
+        # execute `make run` instead of `make run_production` at init:
+        if init:
+            docker_compose["services"]["web"][
+                "command"
+            ] = 'bash -c "source /skyportal_env/bin/activate && (make log &) && make run"'
+        # save the adjusted version
+        with open(
+            "skyportal/docker-compose.skyportal.yaml", "w"
+        ) as docker_compose_yaml:
+            yaml.dump(docker_compose, docker_compose_yaml)
+
+        # Build skyportal's images
+        cmd = ["docker", "build", "."]
+        if skyportal_tag:
+            cmd.extend(["-t", skyportal_tag])
+        print(f"Building SkyPortal docker image (tag: {skyportal_tag})")
+        p = subprocess.run(cmd, cwd="skyportal")
+        if p.returncode != 0:
+            raise RuntimeError("Failed to build skyportal's docker images")
+
+        # when initializing, must start SP to generate token for K
+        if init:
+            # create common docker network (if it does not exist yet)
+            p = subprocess.run(
+                ["docker", "network", "create", "fritz_net"],
+                capture_output=True,
+                universal_newlines=True,
+            )
+            if (p.returncode != 0) and ("already exists" not in p.stderr):
+                raise RuntimeError("Failed to create network fritz_net")
+
+            # start up skyportal
+            # docker-compose.skyportal.yaml bind-mounts the fritz-specific config.yaml and db_seed.yaml
+            p = subprocess.run(
+                ["docker-compose", "-f", "docker-compose.skyportal.yaml", "up", "-d"],
+                cwd="skyportal",
+                check=True,
+            )
+            if p.returncode != 0:
+                raise RuntimeError("Failed to start SkyPortal")
+
+            # init skyportal and load seed data
+            mi, max_retires = 1, 3
+            while mi <= max_retires:
+                p = subprocess.run(
+                    [
+                        "docker",
+                        "exec",
+                        "-i",
+                        "skyportal_web_1",
+                        "/bin/bash",
+                        "-c",
+                        "source /skyportal_env/bin/activate; make db_clear; make db_init;"
+                        "make prepare_seed_data; make load_seed_data",
+                    ],
+                    cwd="skyportal",
+                )
+                if p.returncode == 0:
+                    break
+                else:
+                    print(
+                        "Failed to load seed data into SkyPortal, waiting to retry..."
+                    )
+                    mi += 1
+                    time.sleep(15)
+            if mi == max_retires + 1:
+                raise RuntimeError("Failed to init SkyPortal and load seed data")
+
+            # generate a token for Kowalski to talk to SkyPortal:
+            with open("kowalski/config.yaml") as cyaml:
+                config = yaml.load(cyaml, Loader=yaml.FullLoader)
+
+            token = self._get_skyportal_token()
+            config["kowalski"]["skyportal"]["token"] = token
+
+            # save it to K's config:
+            with open("kowalski/config.yaml", "w") as cyaml:
+                yaml.dump(config, cyaml)
+
+            # update fritz.yaml
+            fritz_config["kowalski"]["skyportal"]["token"] = token
+            with open("fritz.yaml", "w") as fritz_config_yaml:
+                yaml.dump(fritz_config, fritz_config_yaml)
+
+        if not no_kowalski:
+            # Build kowalski's images
+            c = ["python", "kowalski.py", "build"]
+            if yes:
+                c.append("--yes")
+            p = subprocess.run(c, cwd="kowalski")
+            if p.returncode != 0:
+                raise RuntimeError("Failed to build Kowalski's docker images")
+
+        if init:
+            # stop SkyPortal
+            subprocess.run(
+                ["docker-compose", "-f", "docker-compose.skyportal.yaml", "down"],
+                cwd="skyportal",
+            )
+
+            # remove common network
+            subprocess.run(["docker", "network", "remove", "fritz_net"])
+
+    @staticmethod
+    def develop():
+        """Install tools for developing Fritz"""
+        subprocess.run(["pre-commit", "install"])
+
+    def doc(self, yes: bool = True, upload: bool = False):
+        """Build the documentation
+
+        :param yes: agree to all potentially asked questions
+        :param upload: Upload documentation to GitHub
+        """
+        self._check_config(yes=yes)
+        for destination in ("config.yaml.defaults",):
+            subprocess.run(
+                [
+                    "cp",
+                    "config.yaml",
+                    destination,
+                ],
+                check=True,
+                cwd="skyportal",
+            )
+
+        subprocess.run(["make", "html"], cwd="doc", check=True)
+
+        self._patch_skyportal()
+
+        env = os.environ.copy()
+        env.update({"PYTHONPATH": "."})
+
+        from baselayer.app.app_server import handlers as baselayer_handlers
+        from skyportal.app_server import skyportal_handlers
+        from skyportal.app_server_fritz import fritz_handlers
+        from skyportal import openapi
+
+        spec = openapi.spec_from_handlers(
+            baselayer_handlers + skyportal_handlers + fritz_handlers,
+            metadata={
+                "title": "Fritz: SkyPortal API",
+                "servers": [{"url": "https://fritz.science"}],
+            },
+        )
+        with open("skyportal/openapi.json", "w") as f:
+            json.dump(spec.to_dict(), f)
+
+        subprocess.run(
+            [
+                "npx",
+                "redoc-cli@0.9.8",
+                "bundle",
+                "openapi.json",
+                "--title",
+                "Fritz API docs",
+                "--cdn",
+                "--options.theme.logo.gutter",
+                "2rem",
+                "-o",
+                "../doc/_build/html/api.html",
+            ],
+            check=True,
+            cwd="skyportal",
+        )
+        os.remove("skyportal/openapi.json")
+
+        if upload:
+            subprocess.run(
+                [
+                    "./tools/push_dir_to_repo.py",
+                    "--branch",
+                    "master",
+                    "--committer",
+                    "fritz",
+                    "--email",
+                    "fritz@fritz-marshal.org",
+                    "--message",
+                    "Update website",
+                    "--force",
+                    "./doc/_build/html",
+                    "git@github.com:fritz-marshal/doc",
+                ],
+                check=True,
+            )
+
+    def lint(self):
+        """Lint the full code base"""
+        try:
+            import pre_commit  # noqa: F401
+        except ImportError:
+            self.develop()
+
+        try:
+            subprocess.run(["pre-commit", "run", "--all-files"], check=True)
+        except subprocess.CalledProcessError:
+            sys.exit(1)
+
+    @staticmethod
+    def log():
+        """Show SkyPortal's colorized logs while Fritz is running"""
+        p = subprocess.run(
+            [
+                "docker",
+                "exec",
+                "-i",
+                "skyportal_web_1",
+                "/bin/bash",
+                "-c",
+                "source /skyportal_env/bin/activate; make log",
+            ],
+            cwd="skyportal",
+        )
+        if p.returncode != 0:
+            raise RuntimeError("Failed to display fritz's logs")
+
+    def prune(self, yes: bool = True):
+        """☠️ Prune fritz's docker containers and volumes and reset configs to defaults
+
+        :param yes: agree to all potentially asked questions
+        """
+        go = (
             input(
-                f"{c} does not exist, do you want to use {cfg} (not recommended)? [y/N] "
+                "Do you want to prune Fritz's docker containers and volumes and deinit submodules? [y/N] "
             )
             if not yes
             else "y"
         )
-        if cd.lower() == "y":
-            subprocess.run(["cp", f"{cfg}", f"{c}"], check=True)
-        else:
-            raise IOError(f"{c} does not exist, aborting")
 
+        if go.lower() == "y":
+            # try stopping anything that's running first:
+            self.stop()
 
-def check_config(cfg="fritz.defaults.yaml", yes=False, **kwargs):
-    """
-    Check if config exists, generate a K token for SP, adjust cfg and distribute to K and SP
-    """
-    c = cfg.replace(".defaults", "")
-    check_config_exists(cfg=cfg, yes=yes)
+            # remove docker images
+            for image_name in ("kowalski_api", "kowalski_ingester", "skyportal/web"):
+                p1 = subprocess.Popen(["docker", "images"], stdout=subprocess.PIPE)
+                p2 = subprocess.Popen(
+                    ["grep", image_name], stdin=p1.stdout, stdout=subprocess.PIPE
+                )
+                image_id = subprocess.check_output(
+                    ["awk", "{print $3}"], stdin=p2.stdout, universal_newlines=True
+                ).strip()
+                p3 = subprocess.run(["docker", "rmi", image_id])
+                if p3.returncode == 0:
+                    print(f"Removed {image_name} docker image")
+                else:
+                    print(f"Failed to remove {image_name} docker image")
 
-    # generate a token for SkyPortal to talk to Kowalski
-    with open(c) as config_yaml:
-        config = yaml.load(config_yaml, Loader=yaml.FullLoader)
+            # remove docker volumes
+            for volume_name in (
+                "kowalski_data",
+                "kowalski_mongodb",
+                "skyportal_dbdata",
+                "skyportal_thumbnails",
+            ):
+                p = subprocess.run(["docker", "volume", "rm", volume_name])
+                if p.returncode == 0:
+                    print(f"Removed {volume_name} docker volume")
+                else:
+                    print(f"Failed to remove {volume_name} docker volume")
 
-    kowalski_token = generate_kowalski_token(
-        user_id=config["kowalski"]["server"]["admin_username"],
-        jwt_secret=config["kowalski"]["server"]["JWT_SECRET_KEY"],
-        jwt_algorithm=config["kowalski"]["server"]["JWT_ALGORITHM"],
-        jwt_exp_delta_seconds=int(
-            config["kowalski"]["server"]["JWT_EXP_DELTA_SECONDS"]
-        ),
-    )
+            # deinit submodules
+            p = subprocess.run(["git", "submodule", "deinit", "--all", "-f"])
+            if p.returncode == 0:
+                print("Deinitialized fritz's submodules")
+            else:
+                print("Failed to deinit fritz's submodules")
 
-    config["skyportal"]["app"]["kowalski"]["token"] = kowalski_token
+    def run(
+        self,
+        init: bool = False,
+        repo: str = "origin",
+        branch: str = "master",
+        traefik: bool = False,
+        no_kowalski: bool = False,
+        update: bool = True,
+        skyportal_tag: str = "skyportal/web:latest",
+        yes: bool = False,
+    ):
+        """🚀 Launch Fritz"""
+        env = os.environ.copy()
+        env.update({"FLAGS": "--config=../fritz.yaml"})
 
-    # get Docker gateway IP
-    command = [
-        "docker",
-        "network",
-        "inspect",
-        "bridge",
-        '--format={{index .IPAM.Config 0 "Gateway"}}',
-    ]
-    p = subprocess.run(command, stdout=subprocess.PIPE)
-    gateway_ip = p.stdout.decode("utf-8").strip()
-    config["kowalski"]["skyportal"]["host"] = gateway_ip
-    config["skyportal"]["app"]["kowalski"]["host"] = gateway_ip
-
-    # strip down, adjust, and copy over to Kowalski and SkyPortal
-    config_kowalski = {"kowalski": config["kowalski"]}  # don't need the SP stuff
-    with open("kowalski/config.yaml", "w") as config_yaml:
-        yaml.dump(config_kowalski, config_yaml)
-
-    # Docker-specific SkyPortal stuff:
-    config["skyportal"]["database"]["host"] = "db"
-    config["skyportal"]["server"]["url"] = "http://localhost:5000"
-    config_skyportal = config["skyportal"]  # don't need the K stuff
-    with open("skyportal/config.yaml", "w") as config_yaml:
-        yaml.dump(config_skyportal, config_yaml)
-
-    # update fritz.yaml:
-    with open(c, "w") as config_yaml:
-        yaml.dump(config, config_yaml)
-
-
-def update(args):
-    """
-    Update Fritz
-    """
-    p = subprocess.run(["git", "pull", args.repo, args.branch])
-    if p.returncode != 0:
-        raise RuntimeError(f"Failed to git pull Fritz from {args.repo}/{args.branch}")
-
-    if args.init:
-        # initialize/update fritz's submodules kowalski and skyportal
-        # pull skyportal and kowalski
-        p = subprocess.run(["git", "submodule", "update", "--init", "--recursive"])
-        if p.returncode != 0:
-            raise RuntimeError("Failed to initialize fritz's submodules")
-    # auto stash SP
-    p = subprocess.run(["git", "stash"], cwd="skyportal")
-    if p.returncode != 0:
-        raise RuntimeError("SkyPortal autostash failed")
-
-    # update submodules
-    p = subprocess.run(["git", "submodule", "update", "--recursive"])
-    if p.returncode != 0:
-        raise RuntimeError("Failed to update fritz's submodules")
-
-
-def patch_skyportal():
-    """Make fritz-specific file modifications to SkyPortal."""
-    print("Applying fritz-specific patches to SkyPortal")
-
-    p = subprocess.run(["git", "rev-parse", "--short", "HEAD"], stdout=subprocess.PIPE)
-    git_hash = p.stdout.decode("utf-8").strip()
-
-    # add Fritz-specific K and SP extensions
-    # copy_tree('extensions/kowalski/', 'kowalski/')
-    copy_tree("extensions/skyportal/", "skyportal/")
-
-    # Add fritz and SkyPortal git version to skyportal/__init__.py
-    from skyportal import __version__
-
-    init_file = "skyportal/skyportal/__init__.py"
-    with open(init_file, "r") as f:
-        init = f.readlines()
-    out = []
-    for line in init:
-        if line.startswith("__version__ = "):
-            __version__ = "+".join(
-                [v for v in __version__.split("+") if not v.startswith("fritz")]
+        if init:
+            self.build(
+                init=init,
+                repo=repo,
+                branch=branch,
+                traefik=traefik,
+                no_kowalski=no_kowalski,
+                update=update,
+                skyportal_tag=skyportal_tag,
+                yes=yes,
             )
-            line = f'__version__ = "{__version__}+fritz.{git_hash}"\n'
-        out.append(line)
-    with open(init_file, "wb") as f:
-        f.write("".join(out).encode("utf-8"))
 
-    # get the git log for SP and add it to the SP distro
-    p = subprocess.run(
-        [
-            "git",
-            "--git-dir=.git",
-            "log",
-            "--no-merges",
-            "--pretty=format:[%cI %h %cE] %s",
-            "-1000",
-        ],
-        capture_output=True,
-        universal_newlines=True,
-        cwd="skyportal",
-    )
-    out = p.stdout
-    with open("skyportal/data/gitlog.txt", "w") as spgl:
-        spgl.write(out)
-
-    # add Fritz-specific dependencies for SP
-    # js
-    with open("extensions/skyportal/package.fritz.json", "r") as f:
-        fritz_pkg = json.load(f)
-    with open("skyportal/package.json", "r") as f:
-        skyportal_pkg = json.load(f)
-
-    skyportal_pkg["dependencies"] = {
-        **skyportal_pkg["dependencies"],
-        **fritz_pkg["dependencies"],
-    }
-    with open("skyportal/package.json", "w") as f:
-        json.dump(skyportal_pkg, f, indent=2)
-
-    # python
-    with open(".requirements/ext.txt", "r") as f:
-        ext_req = f.readlines()
-    with open("skyportal/requirements.txt", "r") as f:
-        skyportal_req = f.readlines()
-    with open("skyportal/requirements.txt", "w") as f:
-        f.writelines(skyportal_req)
-        for line in ext_req:
-            if line not in skyportal_req:
-                f.write(line)
-
-    # The skyportal .dockerignore includes config.yaml, but we would like
-    # to add that file; we therefore overwrite the .dockerignore
-    with open("skyportal/.dockerignore", "w") as f:
-        f.write(".*\n")
-
-
-def build(args):
-    """
-    Build Fritz
-    """
-    env = os.environ.copy()
-    env.update({"FLAGS": "--config=../fritz.yaml"})
-
-    if not args.dev:
-        update(args)
-
-    # check environment
-    env_ok = dependencies_ok()
-    if not env_ok:
-        raise RuntimeError("Halting because of unsatisfied system dependencies")
-
-    if not args.no_kowalski:
-        # install Kowalski's deps:
-        c = ["pip", "install", "-r", "requirements.txt"]
-        subprocess.run(c, cwd="kowalski", check=True)
-
-    # check config
-    check_config(cfg="fritz.defaults.yaml", yes=args.yes)
-
-    # load config
-    with open("fritz.yaml") as fritz_config_yaml:
-        fritz_config = yaml.load(fritz_config_yaml, Loader=yaml.FullLoader)
-
-    patch_skyportal()
-
-    # adjust F-specific docker-compose.yaml for SP
-    with open("skyportal/docker-compose.skyportal.yaml") as docker_compose_yaml:
-        docker_compose = yaml.load(docker_compose_yaml, Loader=yaml.FullLoader)
-    # fix absolute paths in docker-compose.skyportal.yaml
-    for vi, volume in enumerate(docker_compose["services"]["web"]["volumes"]):
-        docker_compose["services"]["web"]["volumes"][vi] = volume.replace(
-            "${PWD}", str(Path(__file__).parent.absolute())
-        )
-    if args.traefik:
-        # fix host for Traefik
-        docker_compose["services"]["web"]["labels"][2] = docker_compose["services"][
-            "web"
-        ]["labels"][2].replace("<host>", fritz_config["skyportal"]["server"]["host"])
-    else:
-        # not running behind Traefik? then publish port 5000 on host
-        port = fritz_config["skyportal"]["server"].get("port", 5000)
-        if port is None:
-            port = 5000
-        docker_compose["services"]["web"]["ports"] = [f"{port}:{port}"]
-    # execute `make run` instead of `make run_production` at init:
-    if args.init:
-        docker_compose["services"]["web"][
-            "command"
-        ] = 'bash -c "source /skyportal_env/bin/activate && (make log &) && make run"'
-    # save the adjusted version
-    with open("skyportal/docker-compose.skyportal.yaml", "w") as docker_compose_yaml:
-        yaml.dump(docker_compose, docker_compose_yaml)
-
-    # Build skyportal's images
-    cmd = ["docker", "build", "."]
-    if args.skyportal_tag:
-        cmd.extend(["-t", args.skyportal_tag])
-    print(f"Building SkyPortal docker image (tag: {args.skyportal_tag})")
-    p = subprocess.run(cmd, cwd="skyportal")
-    if p.returncode != 0:
-        raise RuntimeError("Failed to build skyportal's docker images")
-
-    # when initializing, must start SP to generate token for K
-    if args.init:
         # create common docker network (if it does not exist yet)
         p = subprocess.run(
             ["docker", "network", "create", "fritz_net"],
@@ -332,58 +606,48 @@ def build(args):
         if p.returncode != 0:
             raise RuntimeError("Failed to start SkyPortal")
 
-        # init skyportal and load seed data
-        mi, max_retires = 1, 3
-        while mi <= max_retires:
-            p = subprocess.run(
-                [
-                    "docker",
-                    "exec",
-                    "-i",
-                    "skyportal_web_1",
-                    "/bin/bash",
-                    "-c",
-                    "source /skyportal_env/bin/activate; make db_clear; make db_init;"
-                    "make prepare_seed_data; make load_seed_data",
-                ],
-                cwd="skyportal",
-            )
-            if p.returncode == 0:
-                break
-            else:
-                print("Failed to load seed data into SkyPortal, waiting to retry...")
-                mi += 1
-                time.sleep(15)
-        if mi == max_retires + 1:
-            raise RuntimeError("Failed to init SkyPortal and load seed data")
-
-        # generate a token for Kowalski to talk to SkyPortal:
-        with open("kowalski/config.yaml") as cyaml:
-            config = yaml.load(cyaml, Loader=yaml.FullLoader)
-
-        token = get_skyportal_token()
-        config["kowalski"]["skyportal"]["token"] = token
-
-        # save it to K's config:
-        with open("kowalski/config.yaml", "w") as cyaml:
-            yaml.dump(config, cyaml)
-
-        # update fritz.yaml
-        fritz_config["kowalski"]["skyportal"]["token"] = token
-        with open("fritz.yaml", "w") as fritz_config_yaml:
-            yaml.dump(fritz_config, fritz_config_yaml)
-
-    if not args.no_kowalski:
-        # Build kowalski's images
-        c = ["python", "kowalski.py", "build"]
-        if args.yes:
-            c.append("--yes")
+        # start up kowalski
+        c = ["python", "kowalski.py", "up"]
         p = subprocess.run(c, cwd="kowalski")
         if p.returncode != 0:
-            raise RuntimeError("Failed to build Kowalski's docker images")
+            raise RuntimeError("Failed to start Kowalski")
 
-    if args.init:
-        # stop SkyPortal
+        if traefik:
+            # check traefik's config
+            self._check_config_exists(
+                cfg="docker-compose.traefik.defaults.yaml", yes=yes
+            )
+            # fire up traefik
+            p = subprocess.run(
+                ["docker-compose", "-f", "docker-compose.traefik.yaml", "up", "-d"],
+                check=True,
+            )
+            if p.returncode != 0:
+                raise RuntimeError("Failed to start Traefik")
+
+    @staticmethod
+    def stop():
+        """✋ Shut Fritz down"""
+        print("Shutting down Fritz...")
+
+        # stop traefik if it is running
+        running_container_images = (
+            subprocess.check_output(["docker", "ps", "-a", "--format", "{{.Image}}"])
+            .decode("utf-8")
+            .strip()
+            .split("\n")
+        )
+        traefik_is_running = any(
+            "traefik" in x.lower() for x in running_container_images
+        )
+        if traefik_is_running:
+            print("Shutting down Traefik")
+            subprocess.run(
+                ["docker-compose", "-f", "docker-compose.traefik.yaml", "down"]
+            )
+
+        # stop Kowalski and SkyPortal
+        subprocess.run(["python", "kowalski.py", "down"], cwd="kowalski")
         subprocess.run(
             ["docker-compose", "-f", "docker-compose.skyportal.yaml", "down"],
             cwd="skyportal",
@@ -392,507 +656,206 @@ def build(args):
         # remove common network
         subprocess.run(["docker", "network", "remove", "fritz_net"])
 
+    def test(self):
+        """Run the test suite"""
+        print("Running integration testing...")
 
-def run(args):
-    """
-    Launch Fritz
-    """
-    env = os.environ.copy()
-    env.update({"FLAGS": "--config=../fritz.yaml"})
+        # load config
+        with open("fritz.yaml") as fritz_config_yaml:
+            fritz_config = yaml.load(fritz_config_yaml, Loader=yaml.FullLoader)
 
-    if args.init:
-        build(args=args)
+        num_retries = 10
+        # make sure the containers are up and running
+        for i in range(num_retries):
+            if i == num_retries - 1:
+                raise RuntimeError("Fritz's containers failed to spin up")
 
-    # create common docker network (if it does not exist yet)
-    p = subprocess.run(
-        ["docker", "network", "create", "fritz_net"],
-        capture_output=True,
-        universal_newlines=True,
-    )
-    if (p.returncode != 0) and ("already exists" not in p.stderr):
-        raise RuntimeError("Failed to create network fritz_net")
+            command = ["docker", "ps", "-a"]
+            container_list = (
+                subprocess.check_output(command, universal_newlines=True)
+                .strip()
+                .split("\n")
+            )
+            if len(container_list) == 1:
+                print("No containers are running, waiting...")
+                time.sleep(3)
+                continue
 
-    # start up skyportal
-    # docker-compose.skyportal.yaml bind-mounts the fritz-specific config.yaml and db_seed.yaml
-    p = subprocess.run(
-        ["docker-compose", "-f", "docker-compose.skyportal.yaml", "up", "-d"],
-        cwd="skyportal",
-        check=True,
-    )
-    if p.returncode != 0:
-        raise RuntimeError("Failed to start SkyPortal")
+            containers_up = (
+                len(
+                    [
+                        container
+                        for container in container_list
+                        if container_name in container and " Up " in container
+                    ]
+                )
+                > 0
+                for container_name in (
+                    "kowalski_ingester_1",
+                    "kowalski_api_1",
+                    "skyportal_web_1",
+                )
+            )
 
-    # start up kowalski
-    c = ["python", "kowalski.py", "up"]
-    p = subprocess.run(c, cwd="kowalski")
-    if p.returncode != 0:
-        raise RuntimeError("Failed to start Kowalski")
+            if not all(containers_up):
+                print("Fritz's containers are not up, waiting...")
+                time.sleep(3)
+                continue
 
-    if args.traefik:
-        # check traefik's config
-        check_config_exists(cfg="docker-compose.traefik.defaults.yaml", yes=args.yes)
-        # fire up traefik
-        p = subprocess.run(
-            ["docker-compose", "-f", "docker-compose.traefik.yaml", "up", "-d"],
-            check=True,
+            break
+
+        # make sure SkyPortal is running
+        for i in range(num_retries):
+            if i == num_retries - 1:
+                raise RuntimeError("SkyPortal failed to spin up")
+
+            command = ["docker", "exec", "-i", "skyportal_web_1", "ps", "-ef"]
+            process_list = subprocess.check_output(
+                command, universal_newlines=True
+            ).strip()
+
+            if "app.py" not in process_list:
+                print("SkyPortal is not up, waiting...")
+                time.sleep(10)
+                continue
+
+            break
+
+        # ensure that the SkyPortal app is responding to requests
+        url = (
+            f"{fritz_config['kowalski']['skyportal']['protocol']}://"
+            f"{fritz_config['kowalski']['skyportal']['host']}:{fritz_config['kowalski']['skyportal']['port']}"
+            "/api/sysinfo"
         )
-        if p.returncode != 0:
-            raise RuntimeError("Failed to start Traefik")
+        token = fritz_config["kowalski"]["skyportal"]["token"]
+        for i in range(num_retries):
+            if i == num_retries - 1:
+                raise RuntimeError("SkyPortal failed to spin up")
+            try:
+                response = self._skyportal_api("GET", endpoint=url, token=token)
 
+                if response.status_code != 200:
+                    print("SkyPortal is not responding, waiting...")
+                    time.sleep(10)
+                else:
+                    break
 
-def stop(args):
-    """
-    Shut down Fritz
-    """
-    print("Shutting down Fritz...")
+            except requests.exceptions.ConnectionError:
+                print("SkyPortal is not responding, waiting...")
+                time.sleep(10)
+                continue
 
-    # stop traefik if it is running
-    running_container_images = (
-        subprocess.check_output(["docker", "ps", "-a", "--format", "{{.Image}}"])
-        .decode("utf-8")
-        .strip()
-        .split("\n")
-    )
-    traefik_is_running = any("traefik" in x.lower() for x in running_container_images)
-    if traefik_is_running:
-        print("Shutting down Traefik")
-        subprocess.run(["docker-compose", "-f", "docker-compose.traefik.yaml", "down"])
+        print("Testing ZTF alert stream consumption and digestion")
 
-    # stop Kowalski and SkyPortal
-    subprocess.run(["python", "kowalski.py", "down"], cwd="kowalski")
-    subprocess.run(
-        ["docker-compose", "-f", "docker-compose.skyportal.yaml", "down"],
-        cwd="skyportal",
-    )
-
-    # remove common network
-    subprocess.run(["docker", "network", "remove", "fritz_net"])
-
-
-def log(args):
-    """
-    Show colorized logs while the marshal is running
-    """
-    # p = subprocess.run(["make", "log"], cwd="skyportal")
-    p = subprocess.run(
-        [
+        command = [
             "docker",
             "exec",
             "-i",
-            "skyportal_web_1",
-            "/bin/bash",
-            "-c",
-            "source /skyportal_env/bin/activate; make log",
-        ],
-        cwd="skyportal",
-    )
-    if p.returncode != 0:
-        raise RuntimeError("Failed to display fritz's logs")
-
-
-def develop(args=None):
-    """
-    Install developer tools.
-    """
-    subprocess.run(["pre-commit", "install"])
-
-
-def lint(args):
-    try:
-        import pre_commit  # noqa: F401
-    except ImportError:
-        develop()
-
-    try:
-        subprocess.run(["pre-commit", "run", "--all-files"], check=True)
-    except subprocess.CalledProcessError:
-        sys.exit(1)
-
-
-def prune(args):
-    """
-    Prune fritz's docker containers and volumes and reset configs to defaults
-    """
-    go = (
-        input(
-            "Do you want to prune Fritz's docker containers and volumes and deinit submodules? [y/N] "
-        )
-        if not args.yes
-        else "y"
-    )
-
-    if go.lower() == "y":
-        # try stopping anything that's running first:
-        stop(args)
-
-        # remove docker images
-        for image_name in ("kowalski_api", "kowalski_ingester", "skyportal/web"):
-            p1 = subprocess.Popen(["docker", "images"], stdout=subprocess.PIPE)
-            p2 = subprocess.Popen(
-                ["grep", image_name], stdin=p1.stdout, stdout=subprocess.PIPE
-            )
-            image_id = subprocess.check_output(
-                ["awk", "{print $3}"], stdin=p2.stdout, universal_newlines=True
-            ).strip()
-            p3 = subprocess.run(["docker", "rmi", image_id])
-            if p3.returncode == 0:
-                print(f"Removed {image_name} docker image")
-            else:
-                print(f"Failed to remove {image_name} docker image")
-
-        # remove docker volumes
-        for volume_name in (
-            "kowalski_data",
-            "kowalski_mongodb",
-            "skyportal_dbdata",
-            "skyportal_thumbnails",
-        ):
-            p = subprocess.run(["docker", "volume", "rm", volume_name])
-            if p.returncode == 0:
-                print(f"Removed {volume_name} docker volume")
-            else:
-                print(f"Failed to remove {volume_name} docker volume")
-
-        # deinit submodules
-        p = subprocess.run(["git", "submodule", "deinit", "--all", "-f"])
-        if p.returncode == 0:
-            print("Deinitialized fritz's submodules")
-        else:
-            print("Failed to deinit fritz's submodules")
-
-
-def test(args):
-    print("Running integration testing...")
-
-    # load config
-    with open("fritz.yaml") as fritz_config_yaml:
-        fritz_config = yaml.load(fritz_config_yaml, Loader=yaml.FullLoader)
-
-    num_retries = 10
-    # make sure the containers are up and running
-    for i in range(num_retries):
-        if i == num_retries - 1:
-            raise RuntimeError("Fritz's containers failed to spin up")
-
-        command = ["docker", "ps", "-a"]
-        container_list = (
-            subprocess.check_output(command, universal_newlines=True)
-            .strip()
-            .split("\n")
-        )
-        if len(container_list) == 1:
-            print("No containers are running, waiting...")
-            time.sleep(3)
-            continue
-
-        containers_up = (
-            len(
-                [
-                    container
-                    for container in container_list
-                    if container_name in container and " Up " in container
-                ]
-            )
-            > 0
-            for container_name in (
-                "kowalski_ingester_1",
-                "kowalski_api_1",
-                "skyportal_web_1",
-            )
-        )
-
-        if not all(containers_up):
-            print("Fritz's containers are not up, waiting...")
-            time.sleep(3)
-            continue
-
-        break
-
-    # make sure SkyPortal is running
-    for i in range(num_retries):
-        if i == num_retries - 1:
-            raise RuntimeError("SkyPortal failed to spin up")
-
-        command = ["docker", "exec", "-i", "skyportal_web_1", "ps", "-ef"]
-        process_list = subprocess.check_output(command, universal_newlines=True).strip()
-
-        if "app.py" not in process_list:
-            print("SkyPortal is not up, waiting...")
-            time.sleep(10)
-            continue
-
-        break
-
-    # ensure that the SkyPortal app is responding to requests
-    url = (
-        f"{fritz_config['kowalski']['skyportal']['protocol']}://"
-        f"{fritz_config['kowalski']['skyportal']['host']}:{fritz_config['kowalski']['skyportal']['port']}"
-        "/api/sysinfo"
-    )
-    token = fritz_config["kowalski"]["skyportal"]["token"]
-    for i in range(num_retries):
-        if i == num_retries - 1:
-            raise RuntimeError("SkyPortal failed to spin up")
+            "kowalski_ingester_1",
+            "python",
+            "-m",
+            "pytest",
+            "-s",
+            "test_ingester.py",
+        ]
         try:
-            response = skyportal_api("GET", endpoint=url, token=token)
+            subprocess.run(command, check=True)
+        except subprocess.CalledProcessError:
+            sys.exit(1)
 
-            if response.status_code != 200:
-                print("SkyPortal is not responding, waiting...")
-                time.sleep(10)
-            else:
-                break
+        # show processing log from dask cluster
+        command = [
+            "docker",
+            "exec",
+            "-i",
+            "kowalski_ingester_1",
+            "cat",
+            "/data/logs/dask_cluster.log",
+        ]
+        try:
+            subprocess.run(command, check=True)
+        except subprocess.CalledProcessError:
+            sys.exit(1)
 
-        except requests.exceptions.ConnectionError:
-            print("SkyPortal is not responding, waiting...")
-            time.sleep(10)
-            continue
+        print("Testing Fritz-specific SkyPortal extensions")
 
-    print("Testing ZTF alert stream consumption and digestion")
-
-    command = [
-        "docker",
-        "exec",
-        "-i",
-        "kowalski_ingester_1",
-        "python",
-        "-m",
-        "pytest",
-        "-s",
-        "test_ingester.py",
-    ]
-    try:
-        subprocess.run(command, check=True)
-    except subprocess.CalledProcessError:
-        sys.exit(1)
-
-    # show processing log from dask cluster
-    command = [
-        "docker",
-        "exec",
-        "-i",
-        "kowalski_ingester_1",
-        "cat",
-        "/data/logs/dask_cluster.log",
-    ]
-    try:
-        subprocess.run(command, check=True)
-    except subprocess.CalledProcessError:
-        sys.exit(1)
-
-    print("Testing Fritz-specific SkyPortal extensions")
-
-    # use the generated config as test config for e.g. the correct db connection details
-    command = [
-        "docker",
-        "exec",
-        "-i",
-        "skyportal_web_1",
-        "cp",
-        "config.yaml",
-        "test_config.yaml",
-    ]
-    try:
-        subprocess.run(command, check=True)
-    except subprocess.CalledProcessError:
-        sys.exit(1)
-
-    api_tests = [
-        test_file.name
-        for test_file in Path("extensions/skyportal/skyportal/tests/api").glob(
-            "test_*.py"
-        )
-    ]
-
-    error = False
-    for api_test in api_tests:
+        # use the generated config as test config for e.g. the correct db connection details
         command = [
             "docker",
             "exec",
             "-i",
             "skyportal_web_1",
-            "/bin/bash",
-            "-c",
-            "source /skyportal_env/bin/activate &&"
-            f"python -m pytest -s skyportal/tests/api/{api_test}",
+            "cp",
+            "config.yaml",
+            "test_config.yaml",
         ]
         try:
             subprocess.run(command, check=True)
         except subprocess.CalledProcessError:
-            error = True
-            continue
-    if error:
-        sys.exit(1)
+            sys.exit(1)
 
+        api_tests = [
+            test_file.name
+            for test_file in Path("extensions/skyportal/skyportal/tests/api").glob(
+                "test_*.py"
+            )
+        ]
 
-def doc(args):
-    check_config(yes=True)
-    for destination in ("config.yaml.defaults",):
-        subprocess.run(
-            [
-                "cp",
-                "config.yaml",
-                destination,
-            ],
-            check=True,
-            cwd="skyportal",
-        )
+        error = False
+        for api_test in api_tests:
+            command = [
+                "docker",
+                "exec",
+                "-i",
+                "skyportal_web_1",
+                "/bin/bash",
+                "-c",
+                "source /skyportal_env/bin/activate &&"
+                f"python -m pytest -s skyportal/tests/api/{api_test}",
+            ]
+            try:
+                subprocess.run(command, check=True)
+            except subprocess.CalledProcessError:
+                error = True
+                continue
+        if error:
+            sys.exit(1)
 
-    subprocess.run(["make", "html"], cwd="doc", check=True)
+    @staticmethod
+    def update(init: bool = False, repo: str = "origin", branch: str = "master"):
+        """Update Fritz
 
-    patch_skyportal()
+        :param init: Initialize before updating Fritz
+        :param repo: Remote repository to pull from
+        :param branch: Branch on the remote repository
+        """
+        p = subprocess.run(["git", "pull", repo, branch])
+        if p.returncode != 0:
+            raise RuntimeError(f"Failed to git pull Fritz from {repo}/{branch}")
 
-    env = os.environ.copy()
-    env.update({"PYTHONPATH": "."})
+        if init:
+            # initialize/update fritz's submodules kowalski and skyportal
+            # pull skyportal and kowalski
+            p = subprocess.run(["git", "submodule", "update", "--init", "--recursive"])
+            if p.returncode != 0:
+                raise RuntimeError("Failed to initialize fritz's submodules")
+        # auto stash SP
+        p = subprocess.run(["git", "stash"], cwd="skyportal")
+        if p.returncode != 0:
+            raise RuntimeError("SkyPortal autostash failed")
 
-    from baselayer.app.app_server import handlers as baselayer_handlers
-    from skyportal.app_server import skyportal_handlers
-    from skyportal.app_server_fritz import fritz_handlers
-    from skyportal import openapi
-
-    spec = openapi.spec_from_handlers(
-        baselayer_handlers + skyportal_handlers + fritz_handlers,
-        metadata={
-            "title": "Fritz: SkyPortal API",
-            "servers": [{"url": "https://fritz.science"}],
-        },
-    )
-    with open("skyportal/openapi.json", "w") as f:
-        json.dump(spec.to_dict(), f)
-
-    subprocess.run(
-        [
-            "npx",
-            "redoc-cli@0.9.8",
-            "bundle",
-            "openapi.json",
-            "--title",
-            "Fritz API docs",
-            "--cdn",
-            "--options.theme.logo.gutter",
-            "2rem",
-            "-o",
-            "../doc/_build/html/api.html",
-        ],
-        check=True,
-        cwd="skyportal",
-    )
-    os.remove("skyportal/openapi.json")
-
-    if args.upload:
-        subprocess.run(
-            [
-                "./tools/push_dir_to_repo.py",
-                "--branch",
-                "master",
-                "--committer",
-                "fritz",
-                "--email",
-                "fritz@fritz-marshal.org",
-                "--message",
-                "Update website",
-                "--force",
-                "./doc/_build/html",
-                "git@github.com:fritz-marshal/doc",
-            ],
-            check=True,
-        )
+        # update submodules
+        p = subprocess.run(["git", "submodule", "update", "--recursive"])
+        if p.returncode != 0:
+            raise RuntimeError("Failed to update fritz's submodules")
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    subparsers = parser.add_subparsers(title="commands", dest="command")
+    # check environment
+    env_ok = dependencies_ok()
+    if not env_ok:
+        raise RuntimeError("Halting because of unsatisfied dependencies")
 
-    parent_parser = argparse.ArgumentParser(add_help=False)
-    parent_parser.add_argument(
-        "--yes", action="store_true", help="Answer yes for all questions"
-    )
+    import fire
 
-    commands = [
-        ("run", "🚀 Launch Fritz"),
-        ("stop", "✋ Shut Fritz down"),
-        ("update", "Update Fritz"),
-        ("build", "Build Fritz"),
-        ("test", "Run the test suite"),
-        ("develop", "Install tools for developing Fritz"),
-        ("lint", "Lint the full code base"),
-        ("prune", "☠️ Wipe out containers, volumes, and submodules"),
-        ("doc", "Build the documentation"),
-        ("help", "Print this message"),
-    ]
-
-    parsers = {}
-    for (cmd, desc) in commands:
-        parsers[cmd] = subparsers.add_parser(cmd, help=desc, parents=[parent_parser])
-
-    p_run = parsers["run"]
-    p_run.add_argument("--init", action="store_true", help="Initialize Fritz")
-    p_run.add_argument(
-        "--repo",
-        type=str,
-        default="origin",
-        help="Remote repository to pull from at init",
-    )
-    p_run.add_argument(
-        "--branch",
-        type=str,
-        default="master",
-        help="Branch on the remote repository at init",
-    )
-    p_run.add_argument("--dev", action="store_true", help="Run Fritz in dev mode")
-    p_run.add_argument(
-        "--traefik", action="store_true", help="Run Fritz behind Traefik"
-    )
-    p_run.add_argument(
-        "--no-kowalski", action="store_true", help="Do not build images for Kowalski"
-    )
-    p_run.add_argument(
-        "--skyportal-tag",
-        default="skyportal/web:latest",
-        help="Tag to apply to SkyPortal docker image",
-    )
-
-    p_build = parsers["build"]
-    p_build.add_argument(
-        "--init", action="store_true", help="Initialize before building Fritz"
-    )
-    p_build.add_argument(
-        "--repo", type=str, default="origin", help="Remote repository to pull from"
-    )
-    p_build.add_argument(
-        "--branch", type=str, default="master", help="Branch on the remote repository"
-    )
-    p_build.add_argument(
-        "--dev", action="store_true", help="Build Fritz for running in dev mode"
-    )
-    p_build.add_argument(
-        "--traefik", action="store_true", help="Build Fritz to run behind Traefik"
-    )
-    p_build.add_argument(
-        "--no-kowalski", action="store_true", help="Do not build images for Kowalski"
-    )
-    p_build.add_argument(
-        "--skyportal-tag",
-        default="skyportal/web:latest",
-        help="Tag to apply to SkyPortal docker image",
-    )
-
-    p_update = parsers["update"]
-    p_update.add_argument(
-        "--init", action="store_true", help="Initialize before updating Fritz"
-    )
-    p_update.add_argument(
-        "--repo", type=str, default="origin", help="Remote repository to pull from"
-    )
-    p_update.add_argument(
-        "--branch", type=str, default="master", help="Branch on the remote repository"
-    )
-
-    parsers["doc"].add_argument(
-        "--upload", action="store_true", help="Upload documentation to GitHub"
-    )
-
-    args = parser.parse_args()
-    if args.command is None or args.command == "help":
-        parser.print_help()
-    else:
-        getattr(sys.modules[__name__], args.command)(args)
+    fire.Fire(Fritz)

--- a/fritz
+++ b/fritz
@@ -159,15 +159,15 @@ class Fritz:
 
         # strip down, adjust, and copy over to Kowalski and SkyPortal
         config_kowalski = {"kowalski": config["kowalski"]}  # don't need the SP stuff
-        with open("kowalski/config.yaml", "w") as config_yaml:
-            yaml.dump(config_kowalski, config_yaml)
+        with open("kowalski/config.yaml", "w") as kowalski_config_yaml:
+            yaml.dump(config_kowalski, kowalski_config_yaml)
 
         # Docker-specific SkyPortal stuff:
         config["skyportal"]["database"]["host"] = "db"
         config["skyportal"]["server"]["url"] = "http://localhost:5000"
         config_skyportal = config["skyportal"]  # don't need the K stuff
-        with open("skyportal/config.yaml", "w") as config_yaml:
-            yaml.dump(config_skyportal, config_yaml)
+        with open("skyportal/config.yaml", "w") as skyportal_config_yaml:
+            yaml.dump(config_skyportal, skyportal_config_yaml)
 
         # update fritz.yaml:
         with open(c, "w") as config_yaml:
@@ -365,15 +365,15 @@ class Fritz:
                 raise RuntimeError("Failed to init SkyPortal and load seed data")
 
             # generate a token for Kowalski to talk to SkyPortal:
-            with open("kowalski/config.yaml") as cyaml:
-                config = yaml.load(cyaml, Loader=yaml.FullLoader)
+            with open("kowalski/config.yaml") as kowalski_config_yaml:
+                config = yaml.load(kowalski_config_yaml, Loader=yaml.FullLoader)
 
             token = self._get_skyportal_token()
             config["kowalski"]["skyportal"]["token"] = token
 
             # save it to K's config:
-            with open("kowalski/config.yaml", "w") as cyaml:
-                yaml.dump(config, cyaml)
+            with open("kowalski/config.yaml", "w") as kowalski_config_yaml:
+                yaml.dump(config, kowalski_config_yaml)
 
             # update fritz.yaml
             fritz_config["kowalski"]["skyportal"]["token"] = token
@@ -728,7 +728,7 @@ class Fritz:
         # ensure that the SkyPortal app is responding to requests
         url = (
             f"{fritz_config['kowalski']['skyportal']['protocol']}://"
-            f"{fritz_config['kowalski']['skyportal']['host']}:{fritz_config['kowalski']['skyportal']['port']}"
+            f"localhost:{fritz_config['kowalski']['skyportal']['port']}"
             "/api/sysinfo"
         )
         token = fritz_config["kowalski"]["skyportal"]["token"]

--- a/fritz
+++ b/fritz
@@ -29,9 +29,6 @@ def initialize_submodules():
 
 
 class Fritz:
-    # def __init__(self):
-    #     pass
-
     @staticmethod
     def _patch_skyportal():
         """Make fritz-specific file modifications to SkyPortal."""
@@ -142,9 +139,7 @@ class Fritz:
             user_id=config["kowalski"]["server"]["admin_username"],
             jwt_secret=config["kowalski"]["server"]["JWT_SECRET_KEY"],
             jwt_algorithm=config["kowalski"]["server"]["JWT_ALGORITHM"],
-            jwt_exp_delta_seconds=int(
-                config["kowalski"]["server"]["JWT_EXP_DELTA_SECONDS"]
-            ),
+            jwt_exp_delta_seconds=config["kowalski"]["server"]["JWT_EXP_DELTA_SECONDS"],
         )
 
         config["skyportal"]["app"]["kowalski"]["token"] = kowalski_token
@@ -189,7 +184,7 @@ class Fritz:
         user_id: str,
         jwt_secret: str,
         jwt_algorithm: str = "HS256",
-        jwt_exp_delta_seconds: int = 30 * 86400 * 12,
+        jwt_exp_delta_seconds: Optional[int] = None,
     ):
         """
         Generate a token for SkyPortal to access Kowalski
@@ -203,13 +198,11 @@ class Fritz:
             "JWT_EXP_DELTA_SECONDS": jwt_exp_delta_seconds,
         }
 
-        payload = {
-            "user_id": jwt_config["user_id"],
-            "exp": (
-                datetime.datetime.utcnow()
-                + datetime.timedelta(seconds=jwt_config["JWT_EXP_DELTA_SECONDS"])
-            ),
-        }
+        payload = {"user_id": jwt_config["user_id"]}
+        if jwt_config["JWT_EXP_DELTA_SECONDS"]:
+            payload["exp"] = datetime.datetime.utcnow() + datetime.timedelta(
+                seconds=jwt_config["JWT_EXP_DELTA_SECONDS"]
+            )
         jwt_token = jwt.encode(
             payload, jwt_config["JWT_SECRET"], jwt_config["JWT_ALGORITHM"]
         )

--- a/fritz
+++ b/fritz
@@ -28,569 +28,288 @@ def initialize_submodules():
             raise RuntimeError("Failed to initialize fritz's submodules")
 
 
-class Fritz:
-    @staticmethod
-    def _patch_skyportal():
-        """Make fritz-specific file modifications to SkyPortal."""
-        print("Applying fritz-specific patches to SkyPortal")
+def patch_skyportal():
+    """Make fritz-specific file modifications to SkyPortal."""
+    print("Applying fritz-specific patches to SkyPortal")
 
-        p = subprocess.run(
-            ["git", "rev-parse", "--short", "HEAD"], stdout=subprocess.PIPE
+    p = subprocess.run(["git", "rev-parse", "--short", "HEAD"], stdout=subprocess.PIPE)
+    git_hash = p.stdout.decode("utf-8").strip()
+
+    # add Fritz-specific SP extensions
+    copy_tree("extensions/skyportal/", "skyportal/")
+
+    # Add fritz and SkyPortal git version to skyportal/__init__.py
+    from skyportal import __version__
+
+    init_file = "skyportal/skyportal/__init__.py"
+    with open(init_file, "r") as f:
+        init = f.readlines()
+    out = []
+    for line in init:
+        if line.startswith("__version__ = "):
+            __version__ = "+".join(
+                [v for v in __version__.split("+") if not v.startswith("fritz")]
+            )
+            line = f'__version__ = "{__version__}+fritz.{git_hash}"\n'
+        out.append(line)
+    with open(init_file, "wb") as f:
+        f.write("".join(out).encode("utf-8"))
+
+    # get the git log for SP and add it to the SP distro
+    p = subprocess.run(
+        [
+            "git",
+            "--git-dir=.git",
+            "log",
+            "--no-merges",
+            "--pretty=format:[%cI %h %cE] %s",
+            "-1000",
+        ],
+        capture_output=True,
+        universal_newlines=True,
+        cwd="skyportal",
+    )
+    out = p.stdout
+    with open("skyportal/data/gitlog.txt", "w") as spgl:
+        spgl.write(out)
+
+    # add Fritz-specific dependencies for SP
+    # js
+    with open("extensions/skyportal/package.fritz.json", "r") as f:
+        fritz_pkg = json.load(f)
+    with open("skyportal/package.json", "r") as f:
+        skyportal_pkg = json.load(f)
+
+    skyportal_pkg["dependencies"] = {
+        **skyportal_pkg["dependencies"],
+        **fritz_pkg["dependencies"],
+    }
+    with open("skyportal/package.json", "w") as f:
+        json.dump(skyportal_pkg, f, indent=2)
+
+    # python
+    with open(".requirements/ext.txt", "r") as f:
+        ext_req = f.readlines()
+    with open("skyportal/requirements.txt", "r") as f:
+        skyportal_req = f.readlines()
+    with open("skyportal/requirements.txt", "w") as f:
+        f.writelines(skyportal_req)
+        for line in ext_req:
+            if line not in skyportal_req:
+                f.write(line)
+
+    # The skyportal .dockerignore includes config.yaml, but we would like
+    # to add that file; we therefore overwrite the .dockerignore
+    with open("skyportal/.dockerignore", "w") as f:
+        f.write(".*\n")
+
+
+def generate_kowalski_token(
+    user_id: str,
+    jwt_secret: str,
+    jwt_algorithm: str = "HS256",
+    jwt_exp_delta_seconds: Optional[int] = None,
+):
+    """
+    Generate a token for SkyPortal to access Kowalski
+    """
+    import jwt
+
+    jwt_config = {
+        "user_id": user_id,
+        "JWT_SECRET": jwt_secret,
+        "JWT_ALGORITHM": jwt_algorithm,
+        "JWT_EXP_DELTA_SECONDS": jwt_exp_delta_seconds,
+    }
+
+    payload = {"user_id": jwt_config["user_id"]}
+    if jwt_config["JWT_EXP_DELTA_SECONDS"]:
+        payload["exp"] = datetime.datetime.utcnow() + datetime.timedelta(
+            seconds=jwt_config["JWT_EXP_DELTA_SECONDS"]
         )
-        git_hash = p.stdout.decode("utf-8").strip()
+    jwt_token = jwt.encode(
+        payload, jwt_config["JWT_SECRET"], jwt_config["JWT_ALGORITHM"]
+    )
 
-        # add Fritz-specific SP extensions
-        copy_tree("extensions/skyportal/", "skyportal/")
+    return jwt_token
 
-        # Add fritz and SkyPortal git version to skyportal/__init__.py
-        from skyportal import __version__
 
-        init_file = "skyportal/skyportal/__init__.py"
-        with open(init_file, "r") as f:
-            init = f.readlines()
-        out = []
-        for line in init:
-            if line.startswith("__version__ = "):
-                __version__ = "+".join(
-                    [v for v in __version__.split("+") if not v.startswith("fritz")]
-                )
-                line = f'__version__ = "{__version__}+fritz.{git_hash}"\n'
-            out.append(line)
-        with open(init_file, "wb") as f:
-            f.write("".join(out).encode("utf-8"))
-
-        # get the git log for SP and add it to the SP distro
-        p = subprocess.run(
-            [
-                "git",
-                "--git-dir=.git",
-                "log",
-                "--no-merges",
-                "--pretty=format:[%cI %h %cE] %s",
-                "-1000",
-            ],
-            capture_output=True,
-            universal_newlines=True,
-            cwd="skyportal",
-        )
-        out = p.stdout
-        with open("skyportal/data/gitlog.txt", "w") as spgl:
-            spgl.write(out)
-
-        # add Fritz-specific dependencies for SP
-        # js
-        with open("extensions/skyportal/package.fritz.json", "r") as f:
-            fritz_pkg = json.load(f)
-        with open("skyportal/package.json", "r") as f:
-            skyportal_pkg = json.load(f)
-
-        skyportal_pkg["dependencies"] = {
-            **skyportal_pkg["dependencies"],
-            **fritz_pkg["dependencies"],
-        }
-        with open("skyportal/package.json", "w") as f:
-            json.dump(skyportal_pkg, f, indent=2)
-
-        # python
-        with open(".requirements/ext.txt", "r") as f:
-            ext_req = f.readlines()
-        with open("skyportal/requirements.txt", "r") as f:
-            skyportal_req = f.readlines()
-        with open("skyportal/requirements.txt", "w") as f:
-            f.writelines(skyportal_req)
-            for line in ext_req:
-                if line not in skyportal_req:
-                    f.write(line)
-
-        # The skyportal .dockerignore includes config.yaml, but we would like
-        # to add that file; we therefore overwrite the .dockerignore
-        with open("skyportal/.dockerignore", "w") as f:
-            f.write(".*\n")
-
-    @staticmethod
-    def _check_config_exists(cfg="fritz.defaults.yaml", yes=False):
-        c = cfg.replace(".defaults", "")
-        if not Path(c).exists():
-            cd = (
-                input(
-                    f"{c} does not exist, do you want to use {cfg} (not recommended)? [y/N] "
-                )
-                if not yes
-                else "y"
-            )
-            if cd.lower() == "y":
-                subprocess.run(["cp", f"{cfg}", f"{c}"], check=True)
-            else:
-                raise IOError(f"{c} does not exist, aborting")
-
-    @classmethod
-    def _check_config(cls, cfg="fritz.defaults.yaml", yes=False):
-        """
-        Check if config exists, generate a K token for SP, adjust cfg and distribute to K and SP
-        """
-        c = cfg.replace(".defaults", "")
-        cls._check_config_exists(cfg=cfg, yes=yes)
-
-        # generate a token for SkyPortal to talk to Kowalski
-        with open(c) as config_yaml:
-            config = yaml.load(config_yaml, Loader=yaml.FullLoader)
-
-        kowalski_token = cls._generate_kowalski_token(
-            user_id=config["kowalski"]["server"]["admin_username"],
-            jwt_secret=config["kowalski"]["server"]["JWT_SECRET_KEY"],
-            jwt_algorithm=config["kowalski"]["server"]["JWT_ALGORITHM"],
-            jwt_exp_delta_seconds=config["kowalski"]["server"]["JWT_EXP_DELTA_SECONDS"],
-        )
-
-        config["skyportal"]["app"]["kowalski"]["token"] = kowalski_token
-
-        # get Docker gateway IP
-        command = [
-            "docker",
-            "network",
-            "inspect",
-            "bridge",
-            '--format={{index .IPAM.Config 0 "Gateway"}}',
-        ]
-        p = subprocess.run(command, stdout=subprocess.PIPE)
-        gateway_ip = p.stdout.decode("utf-8").strip()
-        config["kowalski"]["skyportal"]["host"] = gateway_ip
-        config["skyportal"]["app"]["kowalski"]["host"] = gateway_ip
-
-        # strip down, adjust, and copy over to Kowalski and SkyPortal
-        config_kowalski = {"kowalski": config["kowalski"]}  # don't need the SP stuff
-        with open("kowalski/config.yaml", "w") as kowalski_config_yaml:
-            yaml.dump(config_kowalski, kowalski_config_yaml)
-
-        # Docker-specific SkyPortal stuff:
-        config["skyportal"]["database"]["host"] = "db"
-        config["skyportal"]["server"]["url"] = "http://localhost:5000"
-        config_skyportal = config["skyportal"]  # don't need the K stuff
-        with open("skyportal/config.yaml", "w") as skyportal_config_yaml:
-            yaml.dump(config_skyportal, skyportal_config_yaml)
-
-        # update fritz.yaml:
-        with open(c, "w") as config_yaml:
-            yaml.dump(config, config_yaml)
-
-    @staticmethod
-    def _skyportal_api(method, endpoint, token, data=None):
-        headers = {"Authorization": f"token {token}"}
-        response = requests.request(method, endpoint, json=data, headers=headers)
-        return response
-
-    @staticmethod
-    def _generate_kowalski_token(
-        user_id: str,
-        jwt_secret: str,
-        jwt_algorithm: str = "HS256",
-        jwt_exp_delta_seconds: Optional[int] = None,
-    ):
-        """
-        Generate a token for SkyPortal to access Kowalski
-        """
-        import jwt
-
-        jwt_config = {
-            "user_id": user_id,
-            "JWT_SECRET": jwt_secret,
-            "JWT_ALGORITHM": jwt_algorithm,
-            "JWT_EXP_DELTA_SECONDS": jwt_exp_delta_seconds,
-        }
-
-        payload = {"user_id": jwt_config["user_id"]}
-        if jwt_config["JWT_EXP_DELTA_SECONDS"]:
-            payload["exp"] = datetime.datetime.utcnow() + datetime.timedelta(
-                seconds=jwt_config["JWT_EXP_DELTA_SECONDS"]
-            )
-        jwt_token = jwt.encode(
-            payload, jwt_config["JWT_SECRET"], jwt_config["JWT_ALGORITHM"]
-        )
-
-        return jwt_token
-
-    @staticmethod
-    def _get_skyportal_token():
-        """Get admin token for Kowalski to access SkyPortal"""
-        result = subprocess.run(
-            [
-                "docker",
-                "exec",
-                "-i",
-                "skyportal_web_1",
-                "/bin/bash",
-                "-c",
-                "cat /skyportal/.tokens.yaml",
-            ],
-            cwd="skyportal",
-            capture_output=True,
-            universal_newlines=True,
-        )
-        token = result.stdout.split()[-1]
-
-        if len(token) != 36:
-            raise RuntimeError("Failed to get a SkyPortal token for Kowalski")
-
-        return token
-
-    def build(
-        self,
-        init: bool = False,
-        repo: str = "origin",
-        branch: str = "master",
-        traefik: bool = False,
-        no_kowalski: bool = False,
-        update: bool = False,
-        skyportal_tag: str = "skyportal/web:latest",
-        yes: bool = False,
-    ):
-        """Build Fritz
-
-        :param init: Initialize before updating Fritz
-        :param repo: Remote repository to pull from
-        :param branch: Branch on the remote repository
-        :param traefik: Build Fritz to run behind Traefik
-        :param no_kowalski: Do not build images for Kowalski
-        :param update: pull <repo>/<branch>, autostash SP and update submodules
-        :param skyportal_tag: Tag to apply to SkyPortal docker image
-        :param yes: agree with all potentially asked questions
-        """
-        if update:
-            self.update(init=init, repo=repo, branch=branch)
-
-        if not env_ok:
-            raise RuntimeError("Halting because of unsatisfied system dependencies")
-
-        if not no_kowalski:
-            # install Kowalski's deps:
-            c = ["pip", "install", "-r", "requirements.txt"]
-            subprocess.run(c, cwd="kowalski", check=True)
-
-        # check config
-        self._check_config(cfg="fritz.defaults.yaml", yes=yes)
-
-        # load config
-        with open("fritz.yaml") as fritz_config_yaml:
-            fritz_config = yaml.load(fritz_config_yaml, Loader=yaml.FullLoader)
-
-        self._patch_skyportal()
-
-        # adjust F-specific docker-compose.yaml for SP
-        with open("skyportal/docker-compose.skyportal.yaml") as docker_compose_yaml:
-            docker_compose = yaml.load(docker_compose_yaml, Loader=yaml.FullLoader)
-        # fix absolute paths in docker-compose.skyportal.yaml
-        for vi, volume in enumerate(docker_compose["services"]["web"]["volumes"]):
-            docker_compose["services"]["web"]["volumes"][vi] = volume.replace(
-                "${PWD}", str(Path(__file__).parent.absolute())
-            )
-        if traefik:
-            # fix host for Traefik
-            docker_compose["services"]["web"]["labels"][2] = docker_compose["services"][
-                "web"
-            ]["labels"][2].replace(
-                "<host>", fritz_config["skyportal"]["server"]["host"]
-            )
-        else:
-            # not running behind Traefik? then publish port 5000 on host
-            port = fritz_config["skyportal"]["server"].get("port", 5000)
-            if port is None:
-                port = 5000
-            docker_compose["services"]["web"]["ports"] = [f"{port}:{port}"]
-        # execute `make run` instead of `make run_production` at init:
-        if init:
-            docker_compose["services"]["web"][
-                "command"
-            ] = 'bash -c "source /skyportal_env/bin/activate && (make log &) && make run"'
-        # save the adjusted version
-        with open(
-            "skyportal/docker-compose.skyportal.yaml", "w"
-        ) as docker_compose_yaml:
-            yaml.dump(docker_compose, docker_compose_yaml)
-
-        # Build skyportal's images
-        cmd = ["docker", "build", "."]
-        if skyportal_tag:
-            cmd.extend(["-t", skyportal_tag])
-        print(f"Building SkyPortal docker image (tag: {skyportal_tag})")
-        p = subprocess.run(cmd, cwd="skyportal")
-        if p.returncode != 0:
-            raise RuntimeError("Failed to build skyportal's docker images")
-
-        # when initializing, must start SP to generate token for K
-        if init:
-            # create common docker network (if it does not exist yet)
-            p = subprocess.run(
-                ["docker", "network", "create", "fritz_net"],
-                capture_output=True,
-                universal_newlines=True,
-            )
-            if (p.returncode != 0) and ("already exists" not in p.stderr):
-                raise RuntimeError("Failed to create network fritz_net")
-
-            # start up skyportal
-            # docker-compose.skyportal.yaml bind-mounts the fritz-specific config.yaml and db_seed.yaml
-            p = subprocess.run(
-                ["docker-compose", "-f", "docker-compose.skyportal.yaml", "up", "-d"],
-                cwd="skyportal",
-                check=True,
-            )
-            if p.returncode != 0:
-                raise RuntimeError("Failed to start SkyPortal")
-
-            # init skyportal and load seed data
-            mi, max_retires = 1, 3
-            while mi <= max_retires:
-                p = subprocess.run(
-                    [
-                        "docker",
-                        "exec",
-                        "-i",
-                        "skyportal_web_1",
-                        "/bin/bash",
-                        "-c",
-                        "source /skyportal_env/bin/activate; make db_clear; make db_init;"
-                        "make prepare_seed_data; make load_seed_data",
-                    ],
-                    cwd="skyportal",
-                )
-                if p.returncode == 0:
-                    break
-                else:
-                    print(
-                        "Failed to load seed data into SkyPortal, waiting to retry..."
-                    )
-                    mi += 1
-                    time.sleep(15)
-            if mi == max_retires + 1:
-                raise RuntimeError("Failed to init SkyPortal and load seed data")
-
-            # generate a token for Kowalski to talk to SkyPortal:
-            with open("kowalski/config.yaml") as kowalski_config_yaml:
-                config = yaml.load(kowalski_config_yaml, Loader=yaml.FullLoader)
-
-            token = self._get_skyportal_token()
-            config["kowalski"]["skyportal"]["token"] = token
-
-            # save it to K's config:
-            with open("kowalski/config.yaml", "w") as kowalski_config_yaml:
-                yaml.dump(config, kowalski_config_yaml)
-
-            # update fritz.yaml
-            fritz_config["kowalski"]["skyportal"]["token"] = token
-            with open("fritz.yaml", "w") as fritz_config_yaml:
-                yaml.dump(fritz_config, fritz_config_yaml)
-
-        if not no_kowalski:
-            # Build kowalski's images
-            c = ["python", "kowalski.py", "build"]
-            if yes:
-                c.append("--yes")
-            p = subprocess.run(c, cwd="kowalski")
-            if p.returncode != 0:
-                raise RuntimeError("Failed to build Kowalski's docker images")
-
-        if init:
-            # stop SkyPortal
-            subprocess.run(
-                ["docker-compose", "-f", "docker-compose.skyportal.yaml", "down"],
-                cwd="skyportal",
-            )
-
-            # remove common network
-            subprocess.run(["docker", "network", "remove", "fritz_net"])
-
-    @staticmethod
-    def develop():
-        """Install tools for developing Fritz"""
-        subprocess.run(["pre-commit", "install"])
-
-    def doc(self, yes: bool = False, upload: bool = False):
-        """Build the documentation
-
-        :param yes: agree to all potentially asked questions
-        :param upload: Upload documentation to GitHub
-        """
-        self._check_config(yes=yes)
-        for destination in ("config.yaml.defaults",):
-            subprocess.run(
-                [
-                    "cp",
-                    "config.yaml",
-                    destination,
-                ],
-                check=True,
-                cwd="skyportal",
-            )
-
-        subprocess.run(["make", "html"], cwd="doc", check=True)
-
-        self._patch_skyportal()
-
-        env = os.environ.copy()
-        env.update({"PYTHONPATH": "."})
-
-        from baselayer.app.app_server import handlers as baselayer_handlers
-        from skyportal.app_server import skyportal_handlers
-        from skyportal.app_server_fritz import fritz_handlers
-        from skyportal import openapi
-
-        spec = openapi.spec_from_handlers(
-            baselayer_handlers + skyportal_handlers + fritz_handlers,
-            metadata={
-                "title": "Fritz: SkyPortal API",
-                "servers": [{"url": "https://fritz.science"}],
-            },
-        )
-        with open("skyportal/openapi.json", "w") as f:
-            json.dump(spec.to_dict(), f)
-
-        subprocess.run(
-            [
-                "npx",
-                "redoc-cli@0.9.8",
-                "bundle",
-                "openapi.json",
-                "--title",
-                "Fritz API docs",
-                "--cdn",
-                "--options.theme.logo.gutter",
-                "2rem",
-                "-o",
-                "../doc/_build/html/api.html",
-            ],
-            check=True,
-            cwd="skyportal",
-        )
-        os.remove("skyportal/openapi.json")
-
-        if upload:
-            subprocess.run(
-                [
-                    "./tools/push_dir_to_repo.py",
-                    "--branch",
-                    "master",
-                    "--committer",
-                    "fritz",
-                    "--email",
-                    "fritz@fritz-marshal.org",
-                    "--message",
-                    "Update website",
-                    "--force",
-                    "./doc/_build/html",
-                    "git@github.com:fritz-marshal/doc",
-                ],
-                check=True,
-            )
-
-    def lint(self):
-        """Lint the full code base"""
-        try:
-            import pre_commit  # noqa: F401
-        except ImportError:
-            self.develop()
-
-        try:
-            subprocess.run(["pre-commit", "run", "--all-files"], check=True)
-        except subprocess.CalledProcessError:
-            sys.exit(1)
-
-    @staticmethod
-    def log():
-        """Show SkyPortal's colorized logs while Fritz is running"""
-        p = subprocess.run(
-            [
-                "docker",
-                "exec",
-                "-i",
-                "skyportal_web_1",
-                "/bin/bash",
-                "-c",
-                "source /skyportal_env/bin/activate; make log",
-            ],
-            cwd="skyportal",
-        )
-        if p.returncode != 0:
-            raise RuntimeError("Failed to display fritz's logs")
-
-    def prune(self, yes: bool = False):
-        """☠️ Prune fritz's docker containers and volumes and reset configs to defaults
-
-        :param yes: agree to all potentially asked questions
-        """
-        go = (
+def check_config_exists(cfg="fritz.defaults.yaml", yes=False):
+    c = cfg.replace(".defaults", "")
+    if not Path(c).exists():
+        cd = (
             input(
-                "Do you want to prune Fritz's docker containers and volumes and deinit submodules? [y/N] "
+                f"{c} does not exist, do you want to use {cfg} (not recommended)? [y/N] "
             )
             if not yes
             else "y"
         )
+        if cd.lower() == "y":
+            subprocess.run(["cp", f"{cfg}", f"{c}"], check=True)
+        else:
+            raise IOError(f"{c} does not exist, aborting")
 
-        if go.lower() == "y":
-            # try stopping anything that's running first:
-            self.stop()
 
-            # remove docker images
-            for image_name in ("kowalski_api", "kowalski_ingester", "skyportal/web"):
-                p1 = subprocess.Popen(["docker", "images"], stdout=subprocess.PIPE)
-                p2 = subprocess.Popen(
-                    ["grep", image_name], stdin=p1.stdout, stdout=subprocess.PIPE
-                )
-                image_id = subprocess.check_output(
-                    ["awk", "{print $3}"], stdin=p2.stdout, universal_newlines=True
-                ).strip()
-                p3 = subprocess.run(["docker", "rmi", image_id])
-                if p3.returncode == 0:
-                    print(f"Removed {image_name} docker image")
-                else:
-                    print(f"Failed to remove {image_name} docker image")
+def check_config(cfg="fritz.defaults.yaml", yes=False):
+    """
+    Check if config exists, generate a K token for SP, adjust cfg and distribute to K and SP
+    """
+    c = cfg.replace(".defaults", "")
+    check_config_exists(cfg=cfg, yes=yes)
 
-            # remove docker volumes
-            for volume_name in (
-                "kowalski_data",
-                "kowalski_mongodb",
-                "skyportal_dbdata",
-                "skyportal_thumbnails",
-            ):
-                p = subprocess.run(["docker", "volume", "rm", volume_name])
-                if p.returncode == 0:
-                    print(f"Removed {volume_name} docker volume")
-                else:
-                    print(f"Failed to remove {volume_name} docker volume")
+    # generate a token for SkyPortal to talk to Kowalski
+    with open(c) as config_yaml:
+        config = yaml.load(config_yaml, Loader=yaml.FullLoader)
 
-            # deinit submodules
-            p = subprocess.run(["git", "submodule", "deinit", "--all", "-f"])
-            if p.returncode == 0:
-                print("Deinitialized fritz's submodules")
-            else:
-                print("Failed to deinit fritz's submodules")
+    kowalski_token = generate_kowalski_token(
+        user_id=config["kowalski"]["server"]["admin_username"],
+        jwt_secret=config["kowalski"]["server"]["JWT_SECRET_KEY"],
+        jwt_algorithm=config["kowalski"]["server"]["JWT_ALGORITHM"],
+        jwt_exp_delta_seconds=config["kowalski"]["server"]["JWT_EXP_DELTA_SECONDS"],
+    )
 
-    def run(
-        self,
-        init: bool = False,
-        repo: str = "origin",
-        branch: str = "master",
-        traefik: bool = False,
-        no_kowalski: bool = False,
-        update: bool = False,
-        skyportal_tag: str = "skyportal/web:latest",
-        yes: bool = False,
-    ):
-        """🚀 Launch Fritz"""
-        env = os.environ.copy()
-        env.update({"FLAGS": "--config=../fritz.yaml"})
+    config["skyportal"]["app"]["kowalski"]["token"] = kowalski_token
 
-        if init:
-            self.build(
-                init=init,
-                repo=repo,
-                branch=branch,
-                traefik=traefik,
-                no_kowalski=no_kowalski,
-                update=update,
-                skyportal_tag=skyportal_tag,
-                yes=yes,
-            )
+    # get Docker gateway IP
+    command = [
+        "docker",
+        "network",
+        "inspect",
+        "bridge",
+        '--format={{index .IPAM.Config 0 "Gateway"}}',
+    ]
+    p = subprocess.run(command, stdout=subprocess.PIPE)
+    gateway_ip = p.stdout.decode("utf-8").strip()
+    config["kowalski"]["skyportal"]["host"] = gateway_ip
+    config["skyportal"]["app"]["kowalski"]["host"] = gateway_ip
 
+    # strip down, adjust, and copy over to Kowalski and SkyPortal
+    config_kowalski = {"kowalski": config["kowalski"]}  # don't need the SP stuff
+    with open("kowalski/config.yaml", "w") as kowalski_config_yaml:
+        yaml.dump(config_kowalski, kowalski_config_yaml)
+
+    # Docker-specific SkyPortal stuff:
+    config["skyportal"]["database"]["host"] = "db"
+    config["skyportal"]["server"]["url"] = "http://localhost:5000"
+    config_skyportal = config["skyportal"]  # don't need the K stuff
+    with open("skyportal/config.yaml", "w") as skyportal_config_yaml:
+        yaml.dump(config_skyportal, skyportal_config_yaml)
+
+    # update fritz.yaml:
+    with open(c, "w") as config_yaml:
+        yaml.dump(config, config_yaml)
+
+
+def skyportal_api(method, endpoint, token, data=None):
+    headers = {"Authorization": f"token {token}"}
+    response = requests.request(method, endpoint, json=data, headers=headers)
+    return response
+
+
+def get_skyportal_token():
+    """Get admin token for Kowalski to access SkyPortal"""
+    result = subprocess.run(
+        [
+            "docker",
+            "exec",
+            "-i",
+            "skyportal_web_1",
+            "/bin/bash",
+            "-c",
+            "cat /skyportal/.tokens.yaml",
+        ],
+        cwd="skyportal",
+        capture_output=True,
+        universal_newlines=True,
+    )
+    token = result.stdout.split()[-1]
+
+    if len(token) != 36:
+        raise RuntimeError("Failed to get a SkyPortal token for Kowalski")
+
+    return token
+
+
+def build(
+    init: bool = False,
+    repo: str = "origin",
+    branch: str = "master",
+    traefik: bool = False,
+    no_kowalski: bool = False,
+    do_update: bool = False,
+    skyportal_tag: str = "skyportal/web:latest",
+    yes: bool = False,
+):
+    """Build Fritz
+
+    :param init: Initialize before updating Fritz
+    :param repo: Remote repository to pull from
+    :param branch: Branch on the remote repository
+    :param traefik: Build Fritz to run behind Traefik
+    :param no_kowalski: Do not build images for Kowalski
+    :param do_update: pull <repo>/<branch>, autostash SP and update submodules
+    :param skyportal_tag: Tag to apply to SkyPortal docker image
+    :param yes: agree with all potentially asked questions
+    """
+    if do_update:
+        update(init=init, repo=repo, branch=branch)
+
+    if not env_ok:
+        raise RuntimeError("Halting because of unsatisfied system dependencies")
+
+    if not no_kowalski:
+        # install Kowalski's deps:
+        c = ["pip", "install", "-r", "requirements.txt"]
+        subprocess.run(c, cwd="kowalski", check=True)
+
+    # check config
+    check_config(cfg="fritz.defaults.yaml", yes=yes)
+
+    # load config
+    with open("fritz.yaml") as fritz_config_yaml:
+        fritz_config = yaml.load(fritz_config_yaml, Loader=yaml.FullLoader)
+
+    patch_skyportal()
+
+    # adjust F-specific docker-compose.yaml for SP
+    with open("skyportal/docker-compose.skyportal.yaml") as docker_compose_yaml:
+        docker_compose = yaml.load(docker_compose_yaml, Loader=yaml.FullLoader)
+    # fix absolute paths in docker-compose.skyportal.yaml
+    for vi, volume in enumerate(docker_compose["services"]["web"]["volumes"]):
+        docker_compose["services"]["web"]["volumes"][vi] = volume.replace(
+            "${PWD}", str(Path(__file__).parent.absolute())
+        )
+    if traefik:
+        # fix host for Traefik
+        docker_compose["services"]["web"]["labels"][2] = docker_compose["services"][
+            "web"
+        ]["labels"][2].replace("<host>", fritz_config["skyportal"]["server"]["host"])
+    else:
+        # not running behind Traefik? then publish port 5000 on host
+        port = fritz_config["skyportal"]["server"].get("port", 5000)
+        if port is None:
+            port = 5000
+        docker_compose["services"]["web"]["ports"] = [f"{port}:{port}"]
+    # execute `make run` instead of `make run_production` at init:
+    if init:
+        docker_compose["services"]["web"][
+            "command"
+        ] = 'bash -c "source /skyportal_env/bin/activate && (make log &) && make run"'
+    # save the adjusted version
+    with open("skyportal/docker-compose.skyportal.yaml", "w") as docker_compose_yaml:
+        yaml.dump(docker_compose, docker_compose_yaml)
+
+    # Build skyportal's images
+    cmd = ["docker", "build", "."]
+    if skyportal_tag:
+        cmd.extend(["-t", skyportal_tag])
+    print(f"Building SkyPortal docker image (tag: {skyportal_tag})")
+    p = subprocess.run(cmd, cwd="skyportal")
+    if p.returncode != 0:
+        raise RuntimeError("Failed to build skyportal's docker images")
+
+    # when initializing, must start SP to generate token for K
+    if init:
         # create common docker network (if it does not exist yet)
         p = subprocess.run(
             ["docker", "network", "create", "fritz_net"],
@@ -610,48 +329,58 @@ class Fritz:
         if p.returncode != 0:
             raise RuntimeError("Failed to start SkyPortal")
 
-        # start up kowalski
-        c = ["python", "kowalski.py", "up"]
+        # init skyportal and load seed data
+        mi, max_retires = 1, 3
+        while mi <= max_retires:
+            p = subprocess.run(
+                [
+                    "docker",
+                    "exec",
+                    "-i",
+                    "skyportal_web_1",
+                    "/bin/bash",
+                    "-c",
+                    "source /skyportal_env/bin/activate; make db_clear; make db_init;"
+                    "make prepare_seed_data; make load_seed_data",
+                ],
+                cwd="skyportal",
+            )
+            if p.returncode == 0:
+                break
+            else:
+                print("Failed to load seed data into SkyPortal, waiting to retry...")
+                mi += 1
+                time.sleep(15)
+        if mi == max_retires + 1:
+            raise RuntimeError("Failed to init SkyPortal and load seed data")
+
+        # generate a token for Kowalski to talk to SkyPortal:
+        with open("kowalski/config.yaml") as kowalski_config_yaml:
+            config = yaml.load(kowalski_config_yaml, Loader=yaml.FullLoader)
+
+        token = get_skyportal_token()
+        config["kowalski"]["skyportal"]["token"] = token
+
+        # save it to K's config:
+        with open("kowalski/config.yaml", "w") as kowalski_config_yaml:
+            yaml.dump(config, kowalski_config_yaml)
+
+        # update fritz.yaml
+        fritz_config["kowalski"]["skyportal"]["token"] = token
+        with open("fritz.yaml", "w") as fritz_config_yaml:
+            yaml.dump(fritz_config, fritz_config_yaml)
+
+    if not no_kowalski:
+        # Build kowalski's images
+        c = ["python", "kowalski.py", "build"]
+        if yes:
+            c.append("--yes")
         p = subprocess.run(c, cwd="kowalski")
         if p.returncode != 0:
-            raise RuntimeError("Failed to start Kowalski")
+            raise RuntimeError("Failed to build Kowalski's docker images")
 
-        if traefik:
-            # check traefik's config
-            self._check_config_exists(
-                cfg="docker-compose.traefik.defaults.yaml", yes=yes
-            )
-            # fire up traefik
-            p = subprocess.run(
-                ["docker-compose", "-f", "docker-compose.traefik.yaml", "up", "-d"],
-                check=True,
-            )
-            if p.returncode != 0:
-                raise RuntimeError("Failed to start Traefik")
-
-    @staticmethod
-    def stop():
-        """✋ Shut Fritz down"""
-        print("Shutting down Fritz...")
-
-        # stop traefik if it is running
-        running_container_images = (
-            subprocess.check_output(["docker", "ps", "-a", "--format", "{{.Image}}"])
-            .decode("utf-8")
-            .strip()
-            .split("\n")
-        )
-        traefik_is_running = any(
-            "traefik" in x.lower() for x in running_container_images
-        )
-        if traefik_is_running:
-            print("Shutting down Traefik")
-            subprocess.run(
-                ["docker-compose", "-f", "docker-compose.traefik.yaml", "down"]
-            )
-
-        # stop Kowalski and SkyPortal
-        subprocess.run(["python", "kowalski.py", "down"], cwd="kowalski")
+    if init:
+        # stop SkyPortal
         subprocess.run(
             ["docker-compose", "-f", "docker-compose.skyportal.yaml", "down"],
             cwd="skyportal",
@@ -660,205 +389,462 @@ class Fritz:
         # remove common network
         subprocess.run(["docker", "network", "remove", "fritz_net"])
 
-    def test(self):
-        """Run the test suite"""
-        print("Running integration testing...")
 
-        # load config
-        with open("fritz.yaml") as fritz_config_yaml:
-            fritz_config = yaml.load(fritz_config_yaml, Loader=yaml.FullLoader)
+def develop():
+    """Install tools for developing Fritz"""
+    subprocess.run(["pre-commit", "install"])
 
-        num_retries = 10
-        # make sure the containers are up and running
-        for i in range(num_retries):
-            if i == num_retries - 1:
-                raise RuntimeError("Fritz's containers failed to spin up")
 
-            command = ["docker", "ps", "-a"]
-            container_list = (
-                subprocess.check_output(command, universal_newlines=True)
-                .strip()
-                .split("\n")
-            )
-            if len(container_list) == 1:
-                print("No containers are running, waiting...")
-                time.sleep(3)
-                continue
+def doc(yes: bool = False, upload: bool = False):
+    """Build the documentation
 
-            containers_up = (
-                len(
-                    [
-                        container
-                        for container in container_list
-                        if container_name in container and " Up " in container
-                    ]
-                )
-                > 0
-                for container_name in (
-                    "kowalski_ingester_1",
-                    "kowalski_api_1",
-                    "skyportal_web_1",
-                )
-            )
-
-            if not all(containers_up):
-                print("Fritz's containers are not up, waiting...")
-                time.sleep(3)
-                continue
-
-            break
-
-        # make sure SkyPortal is running
-        for i in range(num_retries):
-            if i == num_retries - 1:
-                raise RuntimeError("SkyPortal failed to spin up")
-
-            command = ["docker", "exec", "-i", "skyportal_web_1", "ps", "-ef"]
-            process_list = subprocess.check_output(
-                command, universal_newlines=True
-            ).strip()
-
-            if "app.py" not in process_list:
-                print("SkyPortal is not up, waiting...")
-                time.sleep(10)
-                continue
-
-            break
-
-        # ensure that the SkyPortal app is responding to requests
-        url = (
-            f"{fritz_config['kowalski']['skyportal']['protocol']}://"
-            f"localhost:{fritz_config['kowalski']['skyportal']['port']}"
-            "/api/sysinfo"
+    :param yes: agree to all potentially asked questions
+    :param upload: Upload documentation to GitHub
+    """
+    check_config(yes=yes)
+    for destination in ("config.yaml.defaults",):
+        subprocess.run(
+            [
+                "cp",
+                "config.yaml",
+                destination,
+            ],
+            check=True,
+            cwd="skyportal",
         )
-        token = fritz_config["kowalski"]["skyportal"]["token"]
-        for i in range(num_retries):
-            if i == num_retries - 1:
-                raise RuntimeError("SkyPortal failed to spin up")
-            try:
-                response = self._skyportal_api("GET", endpoint=url, token=token)
 
-                if response.status_code != 200:
-                    print("SkyPortal is not responding, waiting...")
-                    time.sleep(10)
-                else:
-                    break
+    subprocess.run(["make", "html"], cwd="doc", check=True)
 
-            except requests.exceptions.ConnectionError:
+    patch_skyportal()
+
+    env = os.environ.copy()
+    env.update({"PYTHONPATH": "."})
+
+    from baselayer.app.app_server import handlers as baselayer_handlers
+    from skyportal.app_server import skyportal_handlers
+    from skyportal.app_server_fritz import fritz_handlers
+    from skyportal import openapi
+
+    spec = openapi.spec_from_handlers(
+        baselayer_handlers + skyportal_handlers + fritz_handlers,
+        metadata={
+            "title": "Fritz: SkyPortal API",
+            "servers": [{"url": "https://fritz.science"}],
+        },
+    )
+    with open("skyportal/openapi.json", "w") as f:
+        json.dump(spec.to_dict(), f)
+
+    subprocess.run(
+        [
+            "npx",
+            "redoc-cli@0.9.8",
+            "bundle",
+            "openapi.json",
+            "--title",
+            "Fritz API docs",
+            "--cdn",
+            "--options.theme.logo.gutter",
+            "2rem",
+            "-o",
+            "../doc/_build/html/api.html",
+        ],
+        check=True,
+        cwd="skyportal",
+    )
+    os.remove("skyportal/openapi.json")
+
+    if upload:
+        subprocess.run(
+            [
+                "./tools/push_dir_to_repo.py",
+                "--branch",
+                "master",
+                "--committer",
+                "fritz",
+                "--email",
+                "fritz@fritz-marshal.org",
+                "--message",
+                "Update website",
+                "--force",
+                "./doc/_build/html",
+                "git@github.com:fritz-marshal/doc",
+            ],
+            check=True,
+        )
+
+
+def lint():
+    """Lint the full code base"""
+    try:
+        import pre_commit  # noqa: F401
+    except ImportError:
+        develop()
+
+    try:
+        subprocess.run(["pre-commit", "run", "--all-files"], check=True)
+    except subprocess.CalledProcessError:
+        sys.exit(1)
+
+
+def log():
+    """Show SkyPortal's colorized logs while Fritz is running"""
+    p = subprocess.run(
+        [
+            "docker",
+            "exec",
+            "-i",
+            "skyportal_web_1",
+            "/bin/bash",
+            "-c",
+            "source /skyportal_env/bin/activate; make log",
+        ],
+        cwd="skyportal",
+    )
+    if p.returncode != 0:
+        raise RuntimeError("Failed to display fritz's logs")
+
+
+def prune(yes: bool = False):
+    """☠️ Prune fritz's docker containers and volumes and reset configs to defaults
+
+    :param yes: agree to all potentially asked questions
+    """
+    go = (
+        input(
+            "Do you want to prune Fritz's docker containers and volumes and deinit submodules? [y/N] "
+        )
+        if not yes
+        else "y"
+    )
+
+    if go.lower() == "y":
+        # try stopping anything that's running first:
+        stop()
+
+        # remove docker images
+        for image_name in ("kowalski_api", "kowalski_ingester", "skyportal/web"):
+            p1 = subprocess.Popen(["docker", "images"], stdout=subprocess.PIPE)
+            p2 = subprocess.Popen(
+                ["grep", image_name], stdin=p1.stdout, stdout=subprocess.PIPE
+            )
+            image_id = subprocess.check_output(
+                ["awk", "{print $3}"], stdin=p2.stdout, universal_newlines=True
+            ).strip()
+            p3 = subprocess.run(["docker", "rmi", image_id])
+            if p3.returncode == 0:
+                print(f"Removed {image_name} docker image")
+            else:
+                print(f"Failed to remove {image_name} docker image")
+
+        # remove docker volumes
+        for volume_name in (
+            "kowalski_data",
+            "kowalski_mongodb",
+            "skyportal_dbdata",
+            "skyportal_thumbnails",
+        ):
+            p = subprocess.run(["docker", "volume", "rm", volume_name])
+            if p.returncode == 0:
+                print(f"Removed {volume_name} docker volume")
+            else:
+                print(f"Failed to remove {volume_name} docker volume")
+
+        # deinit submodules
+        p = subprocess.run(["git", "submodule", "deinit", "--all", "-f"])
+        if p.returncode == 0:
+            print("Deinitialized fritz's submodules")
+        else:
+            print("Failed to deinit fritz's submodules")
+
+
+def run(
+    init: bool = False,
+    repo: str = "origin",
+    branch: str = "master",
+    traefik: bool = False,
+    no_kowalski: bool = False,
+    do_update: bool = False,
+    skyportal_tag: str = "skyportal/web:latest",
+    yes: bool = False,
+):
+    """🚀 Launch Fritz"""
+    env = os.environ.copy()
+    env.update({"FLAGS": "--config=../fritz.yaml"})
+
+    if init:
+        build(
+            init=init,
+            repo=repo,
+            branch=branch,
+            traefik=traefik,
+            no_kowalski=no_kowalski,
+            do_update=do_update,
+            skyportal_tag=skyportal_tag,
+            yes=yes,
+        )
+
+    # create common docker network (if it does not exist yet)
+    p = subprocess.run(
+        ["docker", "network", "create", "fritz_net"],
+        capture_output=True,
+        universal_newlines=True,
+    )
+    if (p.returncode != 0) and ("already exists" not in p.stderr):
+        raise RuntimeError("Failed to create network fritz_net")
+
+    # start up skyportal
+    # docker-compose.skyportal.yaml bind-mounts the fritz-specific config.yaml and db_seed.yaml
+    p = subprocess.run(
+        ["docker-compose", "-f", "docker-compose.skyportal.yaml", "up", "-d"],
+        cwd="skyportal",
+        check=True,
+    )
+    if p.returncode != 0:
+        raise RuntimeError("Failed to start SkyPortal")
+
+    # start up kowalski
+    c = ["python", "kowalski.py", "up"]
+    p = subprocess.run(c, cwd="kowalski")
+    if p.returncode != 0:
+        raise RuntimeError("Failed to start Kowalski")
+
+    if traefik:
+        # check traefik's config
+        check_config_exists(cfg="docker-compose.traefik.defaults.yaml", yes=yes)
+        # fire up traefik
+        p = subprocess.run(
+            ["docker-compose", "-f", "docker-compose.traefik.yaml", "up", "-d"],
+            check=True,
+        )
+        if p.returncode != 0:
+            raise RuntimeError("Failed to start Traefik")
+
+
+def stop():
+    """✋ Shut Fritz down"""
+    print("Shutting down Fritz...")
+
+    # stop traefik if it is running
+    running_container_images = (
+        subprocess.check_output(["docker", "ps", "-a", "--format", "{{.Image}}"])
+        .decode("utf-8")
+        .strip()
+        .split("\n")
+    )
+    traefik_is_running = any("traefik" in x.lower() for x in running_container_images)
+    if traefik_is_running:
+        print("Shutting down Traefik")
+        subprocess.run(["docker-compose", "-f", "docker-compose.traefik.yaml", "down"])
+
+    # stop Kowalski and SkyPortal
+    subprocess.run(["python", "kowalski.py", "down"], cwd="kowalski")
+    subprocess.run(
+        ["docker-compose", "-f", "docker-compose.skyportal.yaml", "down"],
+        cwd="skyportal",
+    )
+
+    # remove common network
+    subprocess.run(["docker", "network", "remove", "fritz_net"])
+
+
+def test():
+    """Run the test suite"""
+    print("Running integration testing...")
+
+    # load config
+    with open("fritz.yaml") as fritz_config_yaml:
+        fritz_config = yaml.load(fritz_config_yaml, Loader=yaml.FullLoader)
+
+    num_retries = 10
+    # make sure the containers are up and running
+    for i in range(num_retries):
+        if i == num_retries - 1:
+            raise RuntimeError("Fritz's containers failed to spin up")
+
+        command = ["docker", "ps", "-a"]
+        container_list = (
+            subprocess.check_output(command, universal_newlines=True)
+            .strip()
+            .split("\n")
+        )
+        if len(container_list) == 1:
+            print("No containers are running, waiting...")
+            time.sleep(3)
+            continue
+
+        containers_up = (
+            len(
+                [
+                    container
+                    for container in container_list
+                    if container_name in container and " Up " in container
+                ]
+            )
+            > 0
+            for container_name in (
+                "kowalski_ingester_1",
+                "kowalski_api_1",
+                "skyportal_web_1",
+            )
+        )
+
+        if not all(containers_up):
+            print("Fritz's containers are not up, waiting...")
+            time.sleep(3)
+            continue
+
+        break
+
+    # make sure SkyPortal is running
+    for i in range(num_retries):
+        if i == num_retries - 1:
+            raise RuntimeError("SkyPortal failed to spin up")
+
+        command = ["docker", "exec", "-i", "skyportal_web_1", "ps", "-ef"]
+        process_list = subprocess.check_output(command, universal_newlines=True).strip()
+
+        if "app.py" not in process_list:
+            print("SkyPortal is not up, waiting...")
+            time.sleep(10)
+            continue
+
+        break
+
+    # ensure that the SkyPortal app is responding to requests
+    url = (
+        f"{fritz_config['kowalski']['skyportal']['protocol']}://"
+        f"localhost:{fritz_config['kowalski']['skyportal']['port']}"
+        "/api/sysinfo"
+    )
+    token = fritz_config["kowalski"]["skyportal"]["token"]
+    for i in range(num_retries):
+        if i == num_retries - 1:
+            raise RuntimeError("SkyPortal failed to spin up")
+        try:
+            response = skyportal_api("GET", endpoint=url, token=token)
+
+            if response.status_code != 200:
                 print("SkyPortal is not responding, waiting...")
                 time.sleep(10)
-                continue
+            else:
+                break
 
-        print("Testing ZTF alert stream consumption and digestion")
+        except requests.exceptions.ConnectionError:
+            print("SkyPortal is not responding, waiting...")
+            time.sleep(10)
+            continue
 
-        command = [
-            "docker",
-            "exec",
-            "-i",
-            "kowalski_ingester_1",
-            "python",
-            "-m",
-            "pytest",
-            "-s",
-            "test_ingester.py",
-        ]
-        try:
-            subprocess.run(command, check=True)
-        except subprocess.CalledProcessError:
-            sys.exit(1)
+    print("Testing ZTF alert stream consumption and digestion")
 
-        # show processing log from dask cluster
-        command = [
-            "docker",
-            "exec",
-            "-i",
-            "kowalski_ingester_1",
-            "cat",
-            "/data/logs/dask_cluster.log",
-        ]
-        try:
-            subprocess.run(command, check=True)
-        except subprocess.CalledProcessError:
-            sys.exit(1)
+    command = [
+        "docker",
+        "exec",
+        "-i",
+        "kowalski_ingester_1",
+        "python",
+        "-m",
+        "pytest",
+        "-s",
+        "test_ingester.py",
+    ]
+    try:
+        subprocess.run(command, check=True)
+    except subprocess.CalledProcessError:
+        sys.exit(1)
 
-        print("Testing Fritz-specific SkyPortal extensions")
+    # show processing log from dask cluster
+    command = [
+        "docker",
+        "exec",
+        "-i",
+        "kowalski_ingester_1",
+        "cat",
+        "/data/logs/dask_cluster.log",
+    ]
+    try:
+        subprocess.run(command, check=True)
+    except subprocess.CalledProcessError:
+        sys.exit(1)
 
-        # use the generated config as test config for e.g. the correct db connection details
+    print("Testing Fritz-specific SkyPortal extensions")
+
+    # use the generated config as test config for e.g. the correct db connection details
+    command = [
+        "docker",
+        "exec",
+        "-i",
+        "skyportal_web_1",
+        "cp",
+        "config.yaml",
+        "test_config.yaml",
+    ]
+    try:
+        subprocess.run(command, check=True)
+    except subprocess.CalledProcessError:
+        sys.exit(1)
+
+    api_tests = [
+        test_file.name
+        for test_file in Path("extensions/skyportal/skyportal/tests/api").glob(
+            "test_*.py"
+        )
+    ]
+
+    error = False
+    for api_test in api_tests:
         command = [
             "docker",
             "exec",
             "-i",
             "skyportal_web_1",
-            "cp",
-            "config.yaml",
-            "test_config.yaml",
+            "/bin/bash",
+            "-c",
+            "source /skyportal_env/bin/activate &&"
+            f"python -m pytest -s skyportal/tests/api/{api_test}",
         ]
         try:
             subprocess.run(command, check=True)
         except subprocess.CalledProcessError:
-            sys.exit(1)
+            error = True
+            continue
+    if error:
+        sys.exit(1)
 
-        api_tests = [
-            test_file.name
-            for test_file in Path("extensions/skyportal/skyportal/tests/api").glob(
-                "test_*.py"
-            )
-        ]
 
-        error = False
-        for api_test in api_tests:
-            command = [
-                "docker",
-                "exec",
-                "-i",
-                "skyportal_web_1",
-                "/bin/bash",
-                "-c",
-                "source /skyportal_env/bin/activate &&"
-                f"python -m pytest -s skyportal/tests/api/{api_test}",
-            ]
-            try:
-                subprocess.run(command, check=True)
-            except subprocess.CalledProcessError:
-                error = True
-                continue
-        if error:
-            sys.exit(1)
+def update(
+    init: bool = False,
+    repo: Optional[str] = None,
+    branch: Optional[str] = None,
+):
+    """Update Fritz
 
-    @staticmethod
-    def update(
-        init: bool = False,
-        repo: Optional[str] = None,
-        branch: Optional[str] = None,
-    ):
-        """Update Fritz
+    :param init: Initialize before updating Fritz
+    :param repo: Remote repository to pull from
+    :param branch: Branch on the remote repository
+    """
+    git_pull_command = ["git", "pull"]
+    if repo is not None and branch is not None:
+        git_pull_command.extend([repo, branch])
+    p = subprocess.run(git_pull_command)
+    if p.returncode != 0:
+        raise RuntimeError("Failed to git pull Fritz")
 
-        :param init: Initialize before updating Fritz
-        :param repo: Remote repository to pull from
-        :param branch: Branch on the remote repository
-        """
-        git_pull_command = ["git", "pull"]
-        if repo is not None and branch is not None:
-            git_pull_command.extend([repo, branch])
-        p = subprocess.run(git_pull_command)
+    if init:
+        # initialize/update fritz's submodules kowalski and skyportal
+        # pull skyportal and kowalski
+        p = subprocess.run(["git", "submodule", "update", "--init", "--recursive"])
         if p.returncode != 0:
-            raise RuntimeError("Failed to git pull Fritz")
+            raise RuntimeError("Failed to initialize fritz's submodules")
+    # auto stash SP
+    p = subprocess.run(["git", "stash"], cwd="skyportal")
+    if p.returncode != 0:
+        raise RuntimeError("SkyPortal autostash failed")
 
-        if init:
-            # initialize/update fritz's submodules kowalski and skyportal
-            # pull skyportal and kowalski
-            p = subprocess.run(["git", "submodule", "update", "--init", "--recursive"])
-            if p.returncode != 0:
-                raise RuntimeError("Failed to initialize fritz's submodules")
-        # auto stash SP
-        p = subprocess.run(["git", "stash"], cwd="skyportal")
-        if p.returncode != 0:
-            raise RuntimeError("SkyPortal autostash failed")
-
-        # update submodules
-        p = subprocess.run(["git", "submodule", "update", "--recursive"])
-        if p.returncode != 0:
-            raise RuntimeError("Failed to update fritz's submodules")
+    # update submodules
+    p = subprocess.run(["git", "submodule", "update", "--recursive"])
+    if p.returncode != 0:
+        raise RuntimeError("Failed to update fritz's submodules")
 
 
 if __name__ == "__main__":
@@ -870,4 +856,16 @@ if __name__ == "__main__":
 
     import fire
 
-    fire.Fire(Fritz)
+    fire.Fire(
+        {
+            "run": run,
+            "stop": stop,
+            "build": build,
+            "update": update,
+            "test": test,
+            "develop": develop,
+            "lint": lint,
+            "prune": prune,
+            "doc": doc,
+        }
+    )

--- a/fritz
+++ b/fritz
@@ -234,7 +234,7 @@ class Fritz:
         branch: str = "master",
         traefik: bool = False,
         no_kowalski: bool = False,
-        update: bool = True,
+        update: bool = False,
         skyportal_tag: str = "skyportal/web:latest",
         yes: bool = False,
     ):
@@ -508,7 +508,7 @@ class Fritz:
         if p.returncode != 0:
             raise RuntimeError("Failed to display fritz's logs")
 
-    def prune(self, yes: bool = True):
+    def prune(self, yes: bool = False):
         """☠️ Prune fritz's docker containers and volumes and reset configs to defaults
 
         :param yes: agree to all potentially asked questions
@@ -567,7 +567,7 @@ class Fritz:
         branch: str = "master",
         traefik: bool = False,
         no_kowalski: bool = False,
-        update: bool = True,
+        update: bool = False,
         skyportal_tag: str = "skyportal/web:latest",
         yes: bool = False,
     ):

--- a/fritz
+++ b/fritz
@@ -124,7 +124,7 @@ def check_config(cfg="fritz.defaults.yaml", yes=False, **kwargs):
     p = subprocess.run(command, stdout=subprocess.PIPE)
     gateway_ip = p.stdout.decode("utf-8").strip()
     config["kowalski"]["skyportal"]["host"] = gateway_ip
-    config["skyportal"]["kowalski"]["host"] = gateway_ip
+    config["skyportal"]["app"]["kowalski"]["host"] = gateway_ip
 
     # strip down, adjust, and copy over to Kowalski and SkyPortal
     config_kowalski = {"kowalski": config["kowalski"]}  # don't need the SP stuff

--- a/fritz
+++ b/fritz
@@ -242,7 +242,7 @@ def build(
 ):
     """Build Fritz
 
-    :param init: Initialize before updating Fritz
+    :param init: Initialize Fritz
     :param repo: Remote repository to pull from
     :param branch: Branch on the remote repository
     :param traefik: Build Fritz to run behind Traefik

--- a/fritz
+++ b/fritz
@@ -8,11 +8,24 @@ import requests
 import subprocess
 import sys
 import time
+from typing import Optional
 import yaml
 
 from tools.check_environment import dependencies_ok
 
 sys.path.insert(0, "skyportal")
+
+
+def initialize_submodules():
+    """Initialize submodules if either submodule directory is empty"""
+    do_initialize = any(
+        len(list(Path(submodule).glob("*"))) == 0
+        for submodule in ("kowalski", "skyportal")
+    )
+    if do_initialize:
+        p = subprocess.run(["git", "submodule", "update", "--init", "--recursive"])
+        if p.returncode != 0:
+            raise RuntimeError("Failed to initialize fritz's submodules")
 
 
 class Fritz:
@@ -252,8 +265,6 @@ class Fritz:
         if update:
             self.update(init=init, repo=repo, branch=branch)
 
-        # check environment
-        env_ok = dependencies_ok()
         if not env_ok:
             raise RuntimeError("Halting because of unsatisfied system dependencies")
 
@@ -822,16 +833,23 @@ class Fritz:
             sys.exit(1)
 
     @staticmethod
-    def update(init: bool = False, repo: str = "origin", branch: str = "master"):
+    def update(
+        init: bool = False,
+        repo: Optional[str] = None,
+        branch: Optional[str] = None,
+    ):
         """Update Fritz
 
         :param init: Initialize before updating Fritz
         :param repo: Remote repository to pull from
         :param branch: Branch on the remote repository
         """
-        p = subprocess.run(["git", "pull", repo, branch])
+        git_pull_command = ["git", "pull"]
+        if repo is not None and branch is not None:
+            git_pull_command.extend([repo, branch])
+        p = subprocess.run(git_pull_command)
         if p.returncode != 0:
-            raise RuntimeError(f"Failed to git pull Fritz from {repo}/{branch}")
+            raise RuntimeError("Failed to git pull Fritz")
 
         if init:
             # initialize/update fritz's submodules kowalski and skyportal
@@ -852,6 +870,7 @@ class Fritz:
 
 if __name__ == "__main__":
     # check environment
+    initialize_submodules()
     env_ok = dependencies_ok()
     if not env_ok:
         raise RuntimeError("Halting because of unsatisfied dependencies")

--- a/fritz.defaults.yaml
+++ b/fritz.defaults.yaml
@@ -177,7 +177,7 @@ skyportal:
       # 150px in height. The row height can be altered in the homepage_grid
       # section above (as well as other grid characteristics).
       WeatherWidget:
-        resizeable: false
+        resizeable: true
         layouts:
           xlg: [0, 10, 4, 1]
           lg: [0, 10, 4, 1]
@@ -188,7 +188,7 @@ skyportal:
       SourceCounts:
         props:
           sinceDaysAgo: 7
-        resizeable: false
+        resizeable: true
         layouts:
           xlg: [14, 0, 2, 1]
           lg: [10, 0, 2, 1]
@@ -197,7 +197,7 @@ skyportal:
           xs: [0, 0, 4, 1]
 
       RecentSources:
-        resizeable: false
+        resizeable: true
         layouts:
           xlg: [0, 0, 5, 3]
           lg: [0, 0, 4, 3]
@@ -206,7 +206,7 @@ skyportal:
           xs: [0, 4, 4, 3]
 
       NewsFeed:
-        resizeable: false
+        resizeable: true
         layouts:
           xlg: [10, 0, 4, 3]
           lg: [7, 0, 3, 3]
@@ -215,7 +215,7 @@ skyportal:
           xs: [0, 1, 4, 3]
 
       TopSources:
-        resizeable: false
+        resizeable: true
         layouts:
           xlg: [5, 0, 5, 3]
           lg: [4, 3, 3, 3]

--- a/fritz.defaults.yaml
+++ b/fritz.defaults.yaml
@@ -348,7 +348,7 @@ kowalski:
     version: "2.0.0"
     description: "Kowalski: a toolkit for Time-Domain Astronomy"
     host: "0.0.0.0"
-    port: "4000"
+    port: 4000
     admin_username: "admin"
     # fixme: use ''.join(secrets.choice(string.ascii_lowercase + string.digits) for _ in range(32))
     admin_password: "admin"
@@ -356,7 +356,7 @@ kowalski:
     SECRET_KEY: "abc0123"
     JWT_SECRET_KEY: "abc0123"
     JWT_ALGORITHM: "HS256"
-    JWT_EXP_DELTA_SECONDS: 7776000
+    JWT_EXP_DELTA_SECONDS:
     # fixme: use from cryptography.fernet import Fernet; Fernet.generate_key().decode()
     fernet_key: "irjsxvfJdqSJ2fcnpPacbH972dt-RPMMLE48PQ8J5Hg="
 

--- a/fritz.defaults.yaml
+++ b/fritz.defaults.yaml
@@ -354,6 +354,10 @@ kowalski:
     # fixme: use from cryptography.fernet import Fernet; Fernet.generate_key().decode()
     fernet_key: "irjsxvfJdqSJ2fcnpPacbH972dt-RPMMLE48PQ8J5Hg="
 
+  ztf:
+    # fixme: use the port-forwarded IP for the mountain
+    mountain_ip: null
+
   path:
     app: "/app"
     docs: "/app/docs"
@@ -752,6 +756,11 @@ kowalski:
     logging_level: "debug"
     openapi_validate: False
 
+  slack:
+    # Used by the performance_reporter.py task to post Slack messages
+    slack_bot_token:
+    slack_channel_id:
+
   # this is used to make supervisord.conf files at build time
   supervisord:
     api:
@@ -870,3 +879,13 @@ kowalski:
         stdout_logfile_maxbytes: 30MB
         redirect_stderr: True
         environment: "PRODUCTION=1"
+
+      "program:performance_reporter":
+        command: /usr/local/bin/python performance_reporter.py --send_to_slack --days_ago 1
+        directory: /app
+        user: root
+        autostart: true
+        autorestart: true
+        stdout_logfile: /data/logs/performance_reporter_stdout.log
+        stdout_logfile_maxbytes: 10MB
+        redirect_stderr: True

--- a/fritz.defaults.yaml
+++ b/fritz.defaults.yaml
@@ -334,6 +334,13 @@ skyportal:
     ZTF: data/ztf_standards.csv
     ESO: data/eso_standards.csv
 
+  # Parameters for the thumbnail classification function which labels
+  # images as grayscale or colored. See utils/thumbnail.py for the function.
+  image_grayscale_params:
+    thumb_size: 40
+    MSE_cutoff: 22
+    adjust_color_bias: True
+
   smtp:
     from_email:
     password:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@
 -r .requirements/doc.txt
 -r .requirements/ext.txt
 -r kowalski/requirements.txt
+fire>=0.3.1

--- a/tools/check_environment.py
+++ b/tools/check_environment.py
@@ -136,8 +136,32 @@ def dependencies_ok(check_python_requirements: bool = True):
             )
             print()
 
-    if unsatisfied_system_dependencies or unsatisfied_python_requirements:
+    if unsatisfied_system_dependencies:
         return False
+
+    if unsatisfied_python_requirements:
+        attempt_resolving = input(
+            "Would you like to attempt resolving unsatisfied "
+            "python package requirements in your current environment? [y/N] "
+        ).lower()
+        if attempt_resolving in ("y", "yes", "yup", "yea", "yeah"):
+            p = subprocess.run(
+                [
+                    "python",
+                    "-m",
+                    "pip",
+                    "install",
+                    "-r",
+                    pathlib.Path(__file__).parent.parent.absolute()
+                    / "requirements.txt",
+                ],
+                check=True,
+            )
+            if p.returncode != 0:
+                print("\nAttempt failed.\n")
+                return False
+        else:
+            return False
 
     print("-" * 20)
     return True

--- a/tools/check_environment.py
+++ b/tools/check_environment.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 from distutils.version import LooseVersion as Version
 import subprocess
+import pathlib
+import pkg_resources
 
 from .status import status
 
@@ -12,7 +14,7 @@ def output(cmd):
     return success, out
 
 
-deps = {
+system_dependencies = {
     "python": (
         # Command to get version
         ["python", "--version"],
@@ -40,12 +42,32 @@ deps = {
 }
 
 
-def deps_ok():
+def get_python_requirements(
+    requirements_path: pathlib.Path = pathlib.Path(__file__).parent.parent.absolute(),
+    requirements_file_name: str = "requirements.txt",
+    requirements: list = [],
+):
+    """Recursively get python requirements from requirements.txt-like files"""
+    with open(requirements_path / requirements_file_name) as requirements_file:
+        requirements_from_file = requirements_file.read().splitlines()
+    for requirement in requirements_from_file:
+        if requirement.startswith("-r"):
+            get_python_requirements(
+                requirements_path=requirements_path,
+                requirements_file_name=requirement.split()[1],
+            )
+        else:
+            requirements.append(requirement)
+
+    return list(set(requirements))
+
+
+def dependencies_ok(check_python_requirements: bool = True):
     print("Checking system dependencies:")
 
-    fail = []
+    unsatisfied_system_dependencies = []
 
-    for dep, (cmd, get_version, min_version) in deps.items():
+    for dep, (cmd, get_version, min_version) in system_dependencies.items():
         try:
             query = f"{dep} >= {min_version}"
             with status(query):
@@ -66,24 +88,55 @@ def deps_ok():
             )
             raise
         except Exception as e:
-            fail.append((dep, e))
+            unsatisfied_system_dependencies.append((dep, e))
 
-    if fail:
+    if unsatisfied_system_dependencies:
         print()
         print("[!] Some system dependencies seem to be unsatisfied")
         print()
         print("    The failed checks were:")
         print()
-        for (pkg, exc) in fail:
-            cmd, get_version, min_version = deps[pkg]
+        for (pkg, exc) in unsatisfied_system_dependencies:
+            cmd, get_version, min_version = system_dependencies[pkg]
             print(f'    - {pkg}: `{" ".join(cmd)}`')
             print("     ", exc)
         print()
         print(
-            "    Please refer to https://fritz-marshal.org "
+            "    Please refer to https://docs.fritz.science "
             "for installation instructions."
         )
         print()
+
+    unsatisfied_python_requirements = []
+    if check_python_requirements:
+        print("Checking python requirements:")
+
+        for requirement in get_python_requirements():
+            try:
+                with status(requirement):
+                    pkg_resources.require(requirement)
+            except (
+                pkg_resources.DistributionNotFound,
+                pkg_resources.VersionConflict,
+            ) as e:
+                unsatisfied_python_requirements.append(e.report())
+
+        if unsatisfied_python_requirements:
+            print()
+            print("[!] Some python package requirements seem to be unsatisfied")
+            print()
+            print("    The failed requirements were:")
+            print()
+            for requirement in unsatisfied_python_requirements:
+                print(requirement)
+            print()
+            print(
+                "    Please refer to https://docs.fritz.science "
+                "for installation instructions."
+            )
+            print()
+
+    if unsatisfied_system_dependencies or unsatisfied_python_requirements:
         return False
 
     print("-" * 20)
@@ -91,4 +144,4 @@ def deps_ok():
 
 
 if __name__ == "__main__":
-    deps_ok()
+    dependencies_ok()


### PR DESCRIPTION
In this PR:

- Refactored the `fritz` utility to use `python-fire` instead of `argparse`. This does not touch the logic in `fritz` yet, it is meant to improve the code's readability and maintainability, e.g. we will now be able to utilize typing.
- The `fritz` utility now first checks if python requirements are satisfied in addition to checking system dependencies.