### PR TITLE
pin fritz to version of skyportal with slack integration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "skyportal"]
 	path = skyportal
 	url = git@github.com:fritz-marshal/skyportal
+	branch = revert
 [submodule "kowalski"]
 	path = kowalski
 	url = git@github.com:dmitryduev/kowalski

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "skyportal"]
 	path = skyportal
-	url = git@github.com:skyportal/skyportal
+	url = git@github.com:fritz-marshal/skyportal
 [submodule "kowalski"]
 	path = kowalski
 	url = git@github.com:dmitryduev/kowalski

--- a/fritz.defaults.yaml
+++ b/fritz.defaults.yaml
@@ -116,6 +116,12 @@ skyportal:
         icon: Info
         url: /about
 
+    security:
+      strict: true
+      slack:
+        enabled: false
+        url: null
+
     homepage_grid:
       # This section describes the grid on which Home Page widgets are laid out.
       #


### PR DESCRIPTION
This enables slack integration and relaxes strict permission checking on skyportal 