### PR TITLE
Try to avoid running out of database connections

### DIFF
--- a/extensions/skyportal/skyportal/app_server_fritz.py
+++ b/extensions/skyportal/skyportal/app_server_fritz.py
@@ -1,3 +1,6 @@
+import asyncio
+import concurrent
+
 from skyportal.app_server import make_app
 
 from skyportal.handlers.api.alert import (
@@ -38,6 +41,13 @@ def make_app_fritz(cfg, baselayer_handlers, baselayer_settings, process=None, en
 
     """
     app = make_app(cfg, baselayer_handlers, baselayer_settings, process, env)
+
+    # Limit the number of threads on each Tornado instance.
+    # This is to ensure that we don't run out of database connections,
+    # or overload our SQLAlchemy connection pool.
+    asyncio.get_event_loop().set_default_executor(
+        concurrent.futures.ThreadPoolExecutor(max_workers=8)
+    )
 
     app.add_handlers(r".*", fritz_handlers)  # match any host
 


### PR DESCRIPTION
The error:

```
QueuePool limit of size 5 overflow 10 reached, connection timed out,
timeout 30 (Background on this error at: http://sqlalche.me/e/13/3o7r)
```

This happened because we switched to a single-session-per-request
model.  Now, for each thread on the app server, there will be one or
more session (and, thus, one or more database connection).

Our current SQLAlchemy pool limits are: 5 connections,
with an overrun of 10 (i.e., a maximum of 15 database connections).
This is roughly correct: we run 8 instances of the application, and
8 * 15 = 120 (slightly larger than the 100 connections allowed to
Postgres by default).

With the new thread model, we will have at least nr_threads * nr_apps
connections.  Tornado uses asyncio, which defaults to 5 * NR_CPU
threads, and we have 8 CPUs.  Thus, 40 connections per app instance,
with 8 instances, gives 320 (way over the 100 limit).

The SQLAlchemy thread pool surfaces this error before we ever run into
problems with PostgreSQL, however.  The above is a conservative
analysis, which can potentially become worse when async is employed
inside a handler thread.

The solution proposed here is to limit the number of threads to 8 per
app, bringing us to 8 * 8 = 64 total.  When using async, each thread
can potentially have multiple handlers, but since async handlers are
not very common currently, the extra 36 connections should provide ample buffer.
