### PR TITLE
Make Fritz CLI less noisy

### DIFF
--- a/fritz
+++ b/fritz
@@ -12,6 +12,7 @@ from typing import Optional
 import yaml
 
 from tools.check_environment import dependencies_ok
+from tools.status import status
 
 sys.path.insert(0, "skyportal")
 
@@ -23,7 +24,12 @@ def initialize_submodules():
         for submodule in ("kowalski", "skyportal")
     )
     if do_initialize:
-        p = subprocess.run(["git", "submodule", "update", "--init", "--recursive"])
+        p = subprocess.run(
+            ["git", "submodule", "update", "--init", "--recursive"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+        print(p.stdout.decode("utf-8"))
         if p.returncode != 0:
             raise RuntimeError("Failed to initialize fritz's submodules")
 
@@ -848,13 +854,31 @@ def update(
 
 
 if __name__ == "__main__":
-    # check environment
-    initialize_submodules()
-    env_ok = dependencies_ok()
-    if not env_ok:
-        raise RuntimeError("Halting because of unsatisfied dependencies")
+    try:
+        import fire
+    except ImportError:
+        print("This tool depends on `fire`.  Please install it using:")
+        print()
+        print("  pip install fire")
 
-    import fire
+    # Monkey-patch away fire's paging
+    fire.core.Display = lambda lines, out: print(*lines, file=out)
+
+    # Prevent fire from printing annoying extra debugging information
+    # when the user specifies `--help` instead of `-- --help`
+    if sys.argv[-1] == "--help" and sys.argv[-2] != "":
+        sys.argv.insert(-1, "--")
+
+    # No need to install whole environment if the user just
+    # wants/needs some help
+    if sys.argv[-1] != "--help" and len(sys.argv) != 1:
+        # check environment
+        with status("Initializing submodules"):
+            initialize_submodules()
+        with status("Verifying dependencies"):
+            env_ok = dependencies_ok()
+            if not env_ok:
+                raise RuntimeError("Halting because of unsatisfied dependencies")
 
     fire.Fire(
         {

--- a/tools/check_environment.py
+++ b/tools/check_environment.py
@@ -109,7 +109,7 @@ def dependencies_ok(check_python_requirements: bool = True):
 
     unsatisfied_python_requirements = []
     if check_python_requirements:
-        print("Checking python requirements:")
+        print("\nChecking python requirements:")
 
         for requirement in get_python_requirements():
             try:

--- a/tools/status.py
+++ b/tools/status.py
@@ -1,15 +1,42 @@
 from contextlib import contextmanager
 import sys
+import io
 
 
 @contextmanager
-def status(message):
-    print(f"[·] {message}", end="")
+def redirect_std(out):
+    """
+    Contextmanager to temporarily redirect stdout toa StringIO object.
+
+    """
     sys.stdout.flush()
+    stdout = sys.stdout
     try:
+        sys.stdout = out
         yield
+    finally:
+        sys.stdout = stdout
+
+
+@contextmanager
+def status(message, quiet=True):
+    print(f"[·] {message}", end="")
+
+    fake_stdout = io.StringIO()
+
+    try:
+        with redirect_std(fake_stdout):
+            yield
     except Exception:
         print(f"\r[✗] {message}")
+
+        fake_stdout.seek(0)
+        out = fake_stdout.read().strip()
+        if out:
+            print("-- captured output --")
+            print(out)
+            print("-- end output --")
+
         raise
     else:
         print(f"\r[✓] {message}")

--- a/tools/status.py
+++ b/tools/status.py
@@ -6,7 +6,7 @@ import io
 @contextmanager
 def redirect_std(out):
     """
-    Contextmanager to temporarily redirect stdout toa StringIO object.
+    Contextmanager to temporarily redirect stdout to a StringIO object.
 
     """
     sys.stdout.flush()


### PR DESCRIPTION
This is a start towards cleaning up the fritz CLI output.

1. Remove unnecessary prints from fire
2. Wrap dependency checks and submodule inits with `status`

This is not implemented here, but I recommend we standardize the way we call `subprocess.run` and wrap these in status calls.  This would more clearly indicate where things go wrong (currently, we just exit with an exception).