### PR TITLE
Fix SkyPortal git logs; add Kowalski git logs

### DIFF
--- a/.requirements/ext.txt
+++ b/.requirements/ext.txt
@@ -1,2 +1,3 @@
 penquins>=2.1.0
 pymongo>=3.10.1
+pandas==1.2.2

--- a/.requirements/ext.txt
+++ b/.requirements/ext.txt
@@ -1,3 +1,4 @@
 penquins>=2.1.0
 pymongo>=3.10.1
-pandas==1.2.2
+pandas==1.2
+matplotlib==3.3

--- a/.requirements/ext.txt
+++ b/.requirements/ext.txt
@@ -1,4 +1,2 @@
 penquins>=2.1.0
 pymongo>=3.10.1
-pandas==1.2
-matplotlib==3.3

--- a/extensions/skyportal/static/js/components/About.jsx
+++ b/extensions/skyportal/static/js/components/About.jsx
@@ -305,9 +305,15 @@ const About = () => {
           <Paper mt={1} className={classes.gitlogPaper}>
             <Box p={1}>
               <div>
-                See all pull requests at{" "}
-                <a href="https://github.com/skyportal/skyportal/pulls?q=is%3Apr+">
-                  https://github.com/skyportal/skyportal/pulls
+                See all pull requests for{" "}
+                <a href="https://github.com/fritz-marshal/fritz/pulls">
+                  Fritz
+                </a>, {" "}
+                <a href="https://github.com/skyportal/skyportal/pulls">
+                  SkyPortal
+                </a>, and{" "}
+                <a href="https://github.com/dmitryduev/kowalski/pulls">
+                  Kowalski
                 </a>
               </div>
               <ul className={classes.gitlogList}>

--- a/fritz
+++ b/fritz
@@ -62,9 +62,9 @@ def patch_skyportal():
         f.write("".join(out).encode("utf-8"))
 
     # Add git logs for SkyPortal and Kowalski
-    from skyportal.utils import gitlog
+    from skyportal.utils.gitlog import get_gitlog
 
-    skyportal_log = gitlog.get_gitlog(
+    skyportal_log = get_gitlog(
         cwd="skyportal",
         name="S",
         pr_url_base="https://github.com/skyportal/skyportal/pull",
@@ -74,7 +74,7 @@ def patch_skyportal():
     with open("skyportal/data/gitlog-skyportal.json", "w") as f:
         json.dump(skyportal_log, f)
 
-    kowalski_log = gitlog.get_gitlog(
+    kowalski_log = get_gitlog(
         cwd="kowalski",
         name="K",
         pr_url_base="https://github.com/dmitryduev/kowalski",

--- a/fritz
+++ b/fritz
@@ -61,23 +61,28 @@ def patch_skyportal():
     with open(init_file, "wb") as f:
         f.write("".join(out).encode("utf-8"))
 
-    # get the git log for SP and add it to the SP distro
-    p = subprocess.run(
-        [
-            "git",
-            "--git-dir=.git",
-            "log",
-            "--no-merges",
-            "--pretty=format:[%cI %h %cE] %s",
-            "-1000",
-        ],
-        capture_output=True,
-        universal_newlines=True,
+    # Add git logs for SkyPortal and Kowalski
+    from skyportal.utils import gitlog
+
+    skyportal_log = gitlog.get_gitlog(
         cwd="skyportal",
+        name="S",
+        pr_url_base="https://github.com/skyportal/skyportal/pull",
+        commit_url_base="https://github.com/skyportal/skyportal/commit",
+        N=1000,
     )
-    out = p.stdout
-    with open("skyportal/data/gitlog.txt", "w") as spgl:
-        spgl.write(out)
+    with open("skyportal/data/gitlog-skyportal.json", "w") as f:
+        json.dump(skyportal_log, f)
+
+    kowalski_log = gitlog.get_gitlog(
+        cwd="kowalski",
+        name="K",
+        pr_url_base="https://github.com/dmitryduev/kowalski",
+        commit_url_base="https://github.com/dmitryduev/kowalski/commit",
+        N=1000,
+    )
+    with open("skyportal/data/gitlog-kowalski.json", "w") as f:
+        json.dump(kowalski_log, f)
 
     # add Fritz-specific dependencies for SP
     # js


### PR DESCRIPTION
We now use `skyportal.utils.gitlog.get_gitlog` to generate the logs, instead
of running `git` manually in a subprocess.