### PR TITLE
Updating fritz front-end extensions to implement redshift error display

### DIFF
--- a/extensions/skyportal/static/js/components/SourceDesktop.jsx
+++ b/extensions/skyportal/static/js/components/SourceDesktop.jsx
@@ -13,6 +13,7 @@ import AccordionSummary from "@material-ui/core/AccordionSummary";
 import AccordionDetails from "@material-ui/core/AccordionDetails";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 import Typography from "@material-ui/core/Typography";
+import { log10, abs, ceil } from "mathjs";
 
 import CommentList from "./CommentList";
 import ClassificationList from "./ClassificationList";
@@ -155,6 +156,10 @@ const SourceDesktop = ({ source }) => {
     (g) => !g.single_user_group
   );
 
+  const z_round = source.redshift_error
+    ? ceil(abs(log10(source.redshift_error)))
+    : 4;
+
   return (
     <Grid container spacing={2} className={classes.source}>
       <Grid item xs={7}>
@@ -205,7 +210,9 @@ const SourceDesktop = ({ source }) => {
           <div className={classes.infoLine}>
             <div className={classes.redshiftInfo}>
               <b>Redshift: &nbsp;</b>
-              {source.redshift && source.redshift.toFixed(4)}
+              {source.redshift && source.redshift.toFixed(z_round)}
+              {source.redshift_error && <b>&nbsp; &plusmn; &nbsp;</b>}
+              {source.redshift_error && source.redshift_error.toFixed(z_round)}
               <UpdateSourceRedshift source={source} />
               <SourceRedshiftHistory
                 redshiftHistory={source.redshift_history}
@@ -578,6 +585,7 @@ SourceDesktop.propTypes = {
     loadError: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
     thumbnails: PropTypes.arrayOf(PropTypes.shape({})),
     redshift: PropTypes.number,
+    redshift_error: PropTypes.number,
     groups: PropTypes.arrayOf(PropTypes.shape({})),
     gal_lon: PropTypes.number,
     gal_lat: PropTypes.number,

--- a/extensions/skyportal/static/js/components/SourceMobile.jsx
+++ b/extensions/skyportal/static/js/components/SourceMobile.jsx
@@ -22,6 +22,7 @@ import {
   withOrientationChange,
 } from "react-device-detect";
 import { WidthProvider } from "react-grid-layout";
+import { log10, abs, ceil } from "mathjs";
 
 import CommentListMobile from "./CommentListMobile";
 import ClassificationList from "./ClassificationList";
@@ -200,6 +201,10 @@ const SourceMobile = WidthProvider(
       (g) => !g.single_user_group
     );
 
+    const z_round = source.redshift_error
+      ? ceil(abs(log10(source.redshift_error)))
+      : 4;
+
     let device = "browser";
     if (isMobileOnly) {
       device = isLandscape ? "mobile_landscape" : "mobile_portrait";
@@ -262,7 +267,10 @@ const SourceMobile = WidthProvider(
                   <div className={classes.infoLine}>
                     <div className={classes.redshiftInfo}>
                       <b>Redshift: &nbsp;</b>
-                      {source.redshift && source.redshift.toFixed(4)}
+                      {source.redshift && source.redshift.toFixed(z_round)}
+                      {source.redshift_error && <b>&nbsp; &plusmn; &nbsp;</b>}
+                      {source.redshift_error &&
+                        source.redshift_error.toFixed(z_round)}
                       <UpdateSourceRedshift source={source} />
                       <SourceRedshiftHistory
                         redshiftHistory={source.redshift_history}
@@ -635,6 +643,7 @@ SourceMobile.propTypes = {
     loadError: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
     thumbnails: PropTypes.arrayOf(PropTypes.shape({})),
     redshift: PropTypes.number,
+    redshift_error: PropTypes.number,
     groups: PropTypes.arrayOf(PropTypes.shape({})),
     gal_lon: PropTypes.number,
     gal_lat: PropTypes.number,


### PR DESCRIPTION
Front end display of redshift_error that was merged on skyportal is overwritten by fritz extensions.  This re-adds the front-end display code to the fritz extensions.

Back-end implementation of redshift_error on fritz has been tested and verified.