### PR TITLE
Add buttons to search alerts & LC archive near source on source page

### DIFF
--- a/extensions/skyportal/static/js/components/Alerts.jsx
+++ b/extensions/skyportal/static/js/components/Alerts.jsx
@@ -134,12 +134,10 @@ const Alerts = () => {
   const dispatch = useDispatch();
   const classes = useStyles();
 
-  const [loading, setLoading] = React.useState(false);
-
   const theme = useTheme();
   const darkTheme = theme.palette.type === "dark";
 
-  const alerts = useSelector((state) => state.alerts);
+  const { alerts, queryInProgress } = useSelector((state) => state.alerts);
 
   const makeRow = (alert) => ({
       objectId: alert?.objectId,
@@ -386,17 +384,15 @@ const Alerts = () => {
 
   const { register: registerForm, handleSubmit: handleSubmitForm, control: controlForm } = useForm();
 
-  const submitSearch = async (data) => {
-    setLoading(true);
+  const submitSearch = (data) => {
     const {object_id, ra, dec, radius} = data;
     // check that if positional query is requested then all required data are supplied
     if ((ra.length || dec.length || radius.length) && !(ra.length && dec.length && radius.length)) {
       dispatch(showNotification(`Positional parameters, if specified, must be all set`, "error"));
     }
     else {
-      await dispatch(Actions.fetchAlerts({ object_id, ra, dec, radius }));
+      dispatch(Actions.fetchAlerts({ object_id, ra, dec, radius }));
     }
-    setLoading(false);
   };
 
   return (
@@ -414,12 +410,14 @@ const Alerts = () => {
               <div className={classes.maindiv}>
                 <div className={classes.accordionDetails}>
                   <MuiThemeProvider theme={getMuiTheme(theme)}>
-                    <MUIDataTable
-                      title="Alerts"
-                      data={rows}
-                      columns={columns}
-                      options={options}
-                    />
+                    {queryInProgress ? <CircularProgress /> : (
+                      <MUIDataTable
+                        title="Alerts"
+                        data={rows}
+                        columns={columns}
+                        options={options}
+                      />
+                    )}
                   </MuiThemeProvider>
                 </div>
               </div>
@@ -483,11 +481,11 @@ const Alerts = () => {
                         type="submit"
                         variant="contained"
                         color="primary"
-                        disabled={loading}
+                        disabled={queryInProgress}
                       >
                         Search
                       </Button>
-                      {loading && <CircularProgress size={24} color="secondary" className={classes.buttonProgress} />}
+                      {queryInProgress && <CircularProgress size={24} color="secondary" className={classes.buttonProgress} />}
                     </div>
                   </div>
                 </CardActions>

--- a/extensions/skyportal/static/js/components/AlertsSearchButton.jsx
+++ b/extensions/skyportal/static/js/components/AlertsSearchButton.jsx
@@ -14,7 +14,7 @@ const AlertsSearchButton = ({ objID, ra, dec, radius = 3 }) => {
 
   return (
     <Link to="/alerts" onClick={handleClick}>
-      <Button variant="contained">
+      <Button variant="contained" size="small">
         Search Nearby Alerts
       </Button>
     </Link>

--- a/extensions/skyportal/static/js/components/AlertsSearchButton.jsx
+++ b/extensions/skyportal/static/js/components/AlertsSearchButton.jsx
@@ -15,7 +15,7 @@ const AlertsSearchButton = ({ ra, dec, radius = 3 }) => {
   return (
     <Link to="/alerts" onClick={handleClick}>
       <Button variant="contained" size="small">
-        Search Nearby Alerts
+        Search ZTF Alert Archive
       </Button>
     </Link>
   );

--- a/extensions/skyportal/static/js/components/AlertsSearchButton.jsx
+++ b/extensions/skyportal/static/js/components/AlertsSearchButton.jsx
@@ -6,10 +6,10 @@ import Button from "@material-ui/core/Button";
 
 import * as alertsActions from "../ducks/alerts";
 
-const AlertsSearchButton = ({ objID, ra, dec, radius = 3 }) => {
+const AlertsSearchButton = ({ ra, dec, radius = 3 }) => {
   const dispatch = useDispatch();
   const handleClick = () => {
-    dispatch(alertsActions.fetchAlerts({ object_id: objID, ra, dec, radius }));
+    dispatch(alertsActions.fetchAlerts({ object_id: null, ra, dec, radius }));
   };
 
   return (
@@ -22,7 +22,6 @@ const AlertsSearchButton = ({ objID, ra, dec, radius = 3 }) => {
 };
 
 AlertsSearchButton.propTypes = {
-  objID: PropTypes.string.isRequired,
   ra: PropTypes.number.isRequired,
   dec: PropTypes.number.isRequired,
   radius: PropTypes.number,

--- a/extensions/skyportal/static/js/components/AlertsSearchButton.jsx
+++ b/extensions/skyportal/static/js/components/AlertsSearchButton.jsx
@@ -1,0 +1,34 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { useDispatch } from "react-redux";
+import { Link } from "react-router-dom";
+import Button from "@material-ui/core/Button";
+
+import * as alertsActions from "../ducks/alerts";
+
+const AlertsSearchButton = ({ objID, ra, dec, radius = 3 }) => {
+  const dispatch = useDispatch();
+  const handleClick = () => {
+    dispatch(alertsActions.fetchAlerts({ object_id: objID, ra, dec, radius }));
+  };
+
+  return (
+    <Link to="/alerts" onClick={handleClick}>
+      <Button variant="contained">
+        Search Nearby Alerts
+      </Button>
+    </Link>
+  );
+};
+
+AlertsSearchButton.propTypes = {
+  objID: PropTypes.string.isRequired,
+  ra: PropTypes.number.isRequired,
+  dec: PropTypes.number.isRequired,
+  radius: PropTypes.number,
+};
+AlertsSearchButton.defaultProps = {
+  radius: 3,
+};
+
+export default AlertsSearchButton;

--- a/extensions/skyportal/static/js/components/ArchiveSearchButton.jsx
+++ b/extensions/skyportal/static/js/components/ArchiveSearchButton.jsx
@@ -43,7 +43,7 @@ const ArchiveSearchButton = ({ ra, dec, radius = 3 }) => {
 
   return (
     <Link to="/archive" onClick={handleClick}>
-      <Button variant="contained">View ZTF Light Curve Archive</Button>
+      <Button variant="contained" size="small">View ZTF Light Curve Archive</Button>
     </Link>
   );
 };

--- a/extensions/skyportal/static/js/components/ArchiveSearchButton.jsx
+++ b/extensions/skyportal/static/js/components/ArchiveSearchButton.jsx
@@ -1,0 +1,61 @@
+import React, { useEffect } from "react";
+import PropTypes from "prop-types";
+import { useDispatch, useSelector } from "react-redux";
+import { Link } from "react-router-dom";
+import Button from "@material-ui/core/Button";
+
+import { showNotification } from "baselayer/components/Notifications";
+import * as archiveActions from "../ducks/archive";
+
+const AlertsSearchButton = ({ ra, dec, radius = 3 }) => {
+  const dispatch = useDispatch();
+  const catalogNames = useSelector((state) => state.catalog_names);
+
+  useEffect(() => {
+    const fetchCatalogNames = () => {
+      const data = dispatch(archiveActions.fetchCatalogNames());
+    };
+    if (!catalogNames) {
+      fetchCatalogNames();
+    }
+  }, [catalogNames, dispatch, catalogNamesLoadError]);
+
+  const ZTFLightCurveCatalogNames = catalogNames?.filter(
+    (name) => name.indexOf("ZTF_sources") !== -1
+  );
+  const catalog = ZTFLightCurveCatalogNames[0];
+
+  const handleClick = () => {
+    if (catalog) {
+      dispatch(
+        archiveActions.fetchZTFLightCurves({ catalog, ra, dec, radius })
+      );
+      dispatch(archiveActions.fetchNearestSources({ ra, dec }));
+    } else {
+      dispatch(
+        showNotification(
+          "Catalog names could not be fetched; enter search criteria manually",
+          "warning"
+        )
+      );
+    }
+  };
+
+  return (
+    <Link to="/archive" onClick={handleClick}>
+      <Button variant="contained">View ZTF Light Curve Archive</Button>
+    </Link>
+  );
+};
+
+AlertsSearchButton.propTypes = {
+  objID: PropTypes.string.isRequired,
+  ra: PropTypes.number.isRequired,
+  dec: PropTypes.number.isRequired,
+  radius: PropTypes.number,
+};
+AlertsSearchButton.defaultProps = {
+  radius: 3,
+};
+
+export default AlertsSearchButton;

--- a/extensions/skyportal/static/js/components/ArchiveSearchButton.jsx
+++ b/extensions/skyportal/static/js/components/ArchiveSearchButton.jsx
@@ -7,7 +7,7 @@ import Button from "@material-ui/core/Button";
 import { showNotification } from "baselayer/components/Notifications";
 import * as archiveActions from "../ducks/archive";
 
-const AlertsSearchButton = ({ ra, dec, radius = 3 }) => {
+const ArchiveSearchButton = ({ ra, dec, radius = 3 }) => {
   const dispatch = useDispatch();
   const catalogNames = useSelector((state) => state.catalog_names);
 
@@ -48,14 +48,14 @@ const AlertsSearchButton = ({ ra, dec, radius = 3 }) => {
   );
 };
 
-AlertsSearchButton.propTypes = {
+ArchiveSearchButton.propTypes = {
   objID: PropTypes.string.isRequired,
   ra: PropTypes.number.isRequired,
   dec: PropTypes.number.isRequired,
   radius: PropTypes.number,
 };
-AlertsSearchButton.defaultProps = {
+ArchiveSearchButton.defaultProps = {
   radius: 3,
 };
 
-export default AlertsSearchButton;
+export default ArchiveSearchButton;

--- a/extensions/skyportal/static/js/components/ArchiveSearchButton.jsx
+++ b/extensions/skyportal/static/js/components/ArchiveSearchButton.jsx
@@ -43,7 +43,7 @@ const ArchiveSearchButton = ({ ra, dec, radius = 3 }) => {
 
   return (
     <Link to="/archive" onClick={handleClick}>
-      <Button variant="contained" size="small">View ZTF Light Curve Archive</Button>
+      <Button variant="contained" size="small">Search ZTF Light Curve Archive</Button>
     </Link>
   );
 };

--- a/extensions/skyportal/static/js/components/SourceDesktop.jsx
+++ b/extensions/skyportal/static/js/components/SourceDesktop.jsx
@@ -210,6 +210,22 @@ const SourceDesktop = ({ source }) => {
             </div>
           </div>
           <div className={classes.infoLine}>
+            <div className={classes.sourceInfo}>
+              <AlertsSearchButton ra={source.ra} dec={source.dec} />
+            </div>
+          </div>
+          <div className={classes.infoLine}>
+            <div className={classes.sourceInfo}>
+              <ArchiveSearchButton ra={source.ra} dec={source.dec} />
+            </div>
+          </div>
+          <div className={classes.infoLine}>
+            <div className={classes.sourceInfo}>
+              <b>TNS:&nbsp;</b>
+              <TNSInfo objID={source.id} />
+            </div>
+          </div>
+          <div className={classes.infoLine}>
             <div className={classes.redshiftInfo}>
               <b>Redshift: &nbsp;</b>
               {source.redshift && source.redshift.toFixed(z_round)}
@@ -238,22 +254,6 @@ const SourceDesktop = ({ source }) => {
                   &nbsp; Mpc
                 </div>
               )}
-            </div>
-          </div>
-          <div className={classes.infoLine}>
-            <div className={classes.sourceInfo}>
-              <b>TNS:&nbsp;</b>
-              <TNSInfo objID={source.id} />
-            </div>
-          </div>
-          <div className={classes.infoLine}>
-            <div className={classes.sourceInfo}>
-              <AlertsSearchButton ra={source.ra} dec={source.dec} />
-            </div>
-          </div>
-          <div className={classes.infoLine}>
-            <div className={classes.sourceInfo}>
-              <ArchiveSearchButton ra={source.ra} dec={source.dec} />
             </div>
           </div>
           <div className={`${classes.infoLine} ${classes.findingChart}`}>

--- a/extensions/skyportal/static/js/components/SourceDesktop.jsx
+++ b/extensions/skyportal/static/js/components/SourceDesktop.jsx
@@ -37,6 +37,7 @@ import SourceSaveHistory from "./SourceSaveHistory";
 import PhotometryTable from "./PhotometryTable";
 import FavoritesButton from "./FavoritesButton";
 import TNSInfo from "./TNSInfo";
+import AlertsSearchButton from "./AlertsSearchButton";
 
 const VegaHR = React.lazy(() => import("./VegaHR"));
 
@@ -242,6 +243,11 @@ const SourceDesktop = ({ source }) => {
             <div className={classes.sourceInfo}>
               <b>TNS:&nbsp;</b>
               <TNSInfo objID={source.id} />
+            </div>
+          </div>
+          <div className={classes.infoLine}>
+            <div className={classes.sourceInfo}>
+              <AlertsSearchButton objID={source.id} ra={source.ra} dec={source.dec} />
             </div>
           </div>
           <div className={`${classes.infoLine} ${classes.findingChart}`}>

--- a/extensions/skyportal/static/js/components/SourceDesktop.jsx
+++ b/extensions/skyportal/static/js/components/SourceDesktop.jsx
@@ -248,7 +248,7 @@ const SourceDesktop = ({ source }) => {
           </div>
           <div className={classes.infoLine}>
             <div className={classes.sourceInfo}>
-              <AlertsSearchButton objID={source.id} ra={source.ra} dec={source.dec} />
+              <AlertsSearchButton ra={source.ra} dec={source.dec} />
             </div>
           </div>
           <div className={classes.infoLine}>

--- a/extensions/skyportal/static/js/components/SourceDesktop.jsx
+++ b/extensions/skyportal/static/js/components/SourceDesktop.jsx
@@ -38,6 +38,7 @@ import PhotometryTable from "./PhotometryTable";
 import FavoritesButton from "./FavoritesButton";
 import TNSInfo from "./TNSInfo";
 import AlertsSearchButton from "./AlertsSearchButton";
+import ArchiveSearchButton from "./ArchiveSearchButton";
 
 const VegaHR = React.lazy(() => import("./VegaHR"));
 
@@ -248,6 +249,11 @@ const SourceDesktop = ({ source }) => {
           <div className={classes.infoLine}>
             <div className={classes.sourceInfo}>
               <AlertsSearchButton objID={source.id} ra={source.ra} dec={source.dec} />
+            </div>
+          </div>
+          <div className={classes.infoLine}>
+            <div className={classes.sourceInfo}>
+              <ArchiveSearchButton ra={source.ra} dec={source.dec} />
             </div>
           </div>
           <div className={`${classes.infoLine} ${classes.findingChart}`}>

--- a/extensions/skyportal/static/js/components/SourceMobile.jsx
+++ b/extensions/skyportal/static/js/components/SourceMobile.jsx
@@ -267,6 +267,22 @@ const SourceMobile = WidthProvider(
                     </div>
                   </div>
                   <div className={classes.infoLine}>
+                    <div className={classes.sourceInfo}>
+                      <AlertsSearchButton objID={source.id} ra={source.ra} dec={source.dec} />
+                    </div>
+                  </div>
+                  <div className={classes.infoLine}>
+                    <div className={classes.sourceInfo}>
+                      <ArchiveSearchButton ra={source.ra} dec={source.dec} />
+                    </div>
+                  </div>
+                  <div className={classes.infoLine}>
+                    <div className={classes.sourceInfo}>
+                      <b>TNS:&nbsp;</b>
+                      <TNSInfo objID={source.id} />
+                    </div>
+                  </div>
+                  <div className={classes.infoLine}>
                     <div className={classes.redshiftInfo}>
                       <b>Redshift: &nbsp;</b>
                       {source.redshift && source.redshift.toFixed(z_round)}
@@ -296,22 +312,6 @@ const SourceMobile = WidthProvider(
                           &nbsp; Mpc
                         </div>
                       )}
-                    </div>
-                  </div>
-                  <div className={classes.infoLine}>
-                    <div className={classes.sourceInfo}>
-                      <b>TNS:&nbsp;</b>
-                      <TNSInfo objID={source.id} />
-                    </div>
-                  </div>
-                  <div className={classes.infoLine}>
-                    <div className={classes.sourceInfo}>
-                      <AlertsSearchButton objID={source.id} ra={source.ra} dec={source.dec} />
-                    </div>
-                  </div>
-                  <div className={classes.infoLine}>
-                    <div className={classes.sourceInfo}>
-                      <ArchiveSearchButton ra={source.ra} dec={source.dec} />
                     </div>
                   </div>
                   <div

--- a/extensions/skyportal/static/js/components/SourceMobile.jsx
+++ b/extensions/skyportal/static/js/components/SourceMobile.jsx
@@ -47,6 +47,7 @@ import PhotometryTable from "./PhotometryTable";
 import FavoritesButton from "./FavoritesButton";
 import TNSInfo from "./TNSInfo";
 import AlertsSearchButton from "./AlertsSearchButton";
+import ArchiveSearchButton from "./ArchiveSearchButton";
 
 const VegaHR = React.lazy(() => import("./VegaHR"));
 
@@ -306,6 +307,11 @@ const SourceMobile = WidthProvider(
                   <div className={classes.infoLine}>
                     <div className={classes.sourceInfo}>
                       <AlertsSearchButton objID={source.id} ra={source.ra} dec={source.dec} />
+                    </div>
+                  </div>
+                  <div className={classes.infoLine}>
+                    <div className={classes.sourceInfo}>
+                      <ArchiveSearchButton ra={source.ra} dec={source.dec} />
                     </div>
                   </div>
                   <div

--- a/extensions/skyportal/static/js/components/SourceMobile.jsx
+++ b/extensions/skyportal/static/js/components/SourceMobile.jsx
@@ -46,6 +46,7 @@ import SourceSaveHistory from "./SourceSaveHistory";
 import PhotometryTable from "./PhotometryTable";
 import FavoritesButton from "./FavoritesButton";
 import TNSInfo from "./TNSInfo";
+import AlertsSearchButton from "./AlertsSearchButton";
 
 const VegaHR = React.lazy(() => import("./VegaHR"));
 
@@ -300,6 +301,11 @@ const SourceMobile = WidthProvider(
                     <div className={classes.sourceInfo}>
                       <b>TNS:&nbsp;</b>
                       <TNSInfo objID={source.id} />
+                    </div>
+                  </div>
+                  <div className={classes.infoLine}>
+                    <div className={classes.sourceInfo}>
+                      <AlertsSearchButton objID={source.id} ra={source.ra} dec={source.dec} />
                     </div>
                   </div>
                   <div

--- a/extensions/skyportal/static/js/ducks/alerts.js
+++ b/extensions/skyportal/static/js/ducks/alerts.js
@@ -30,16 +30,31 @@ export const fetchAlerts = ({ object_id, ra, dec, radius }) => {
   )
 }
 
-const reducer = (state = null, action) => {
+const reducer = (state = { alerts: null, queryInProgress: false }, action) => {
   switch (action.type) {
+    case FETCH_ALERTS: {
+      return {
+        ...state,
+        queryInProgress: true,
+      };
+    }
     case FETCH_ALERTS_OK: {
-      return action.data;
+      return {
+        alerts: action.data,
+        queryInProgress: false,
+      };
     }
     case FETCH_ALERTS_ERROR: {
-      return action.message;
+      return {
+        message: action.message,
+        queryInProgress: false,
+      };
     }
     case FETCH_ALERTS_FAIL: {
-      return "uncaught error";
+      return {
+        message: "uncaught error",
+        queryInProgress: false,
+      };
     }
     default:
       return state;

--- a/extensions/skyportal/static/js/ducks/archive.js
+++ b/extensions/skyportal/static/js/ducks/archive.js
@@ -49,16 +49,33 @@ export function saveLightCurves(payload) {
   return API.POST(`/api/archive`, SAVE_LIGHT_CURVES, payload);
 }
 
-const reducer = (state = null, action) => {
+const reducer = (state = { lightCurves: null, queryInProgress: false }, action) => {
   switch (action.type) {
+    case FETCH_ZTF_LIGHT_CURVES: {
+      return {
+        ...state,
+        queryInProgress: true,
+      };
+    }
     case FETCH_ZTF_LIGHT_CURVES_OK: {
-      return action.data;
+      return {
+        lightCurves: action.data,
+        queryInProgress: false,
+      };
     }
     case FETCH_ZTF_LIGHT_CURVES_ERROR: {
-      return action.message;
+      return {
+        lightCurves: null,
+        message: action.message,
+        queryInProgress: false,
+      };
     }
     case FETCH_ZTF_LIGHT_CURVES_FAIL: {
-      return "uncaught error";
+      return {
+        lightCurves: null,
+        message: "uncaught error",
+        queryInProgress: false,
+      };
     }
     default:
       return state;


### PR DESCRIPTION
This PR introduces a button to the source page that, when clicked, submits a request to query alerts within 3 arcseconds of the source in question and redirects to the alerts page to render the results. Other improvements to the alerts page, including a spinner during request processing, and redux state structure updates, are included.

Closes  https://github.com/fritz-marshal/fritz/issues/287

![alerts_search_button](https://user-images.githubusercontent.com/7230285/120868269-87b47580-c548-11eb-8c45-939efedd6194.gif)
