### PR TITLE
Add basic ACAI plot to source page + Update CentroidPlot.jsx

### DIFF
--- a/extensions/skyportal/static/js/components/AcaiPlot.jsx
+++ b/extensions/skyportal/static/js/components/AcaiPlot.jsx
@@ -1,0 +1,187 @@
+import React, { useState } from "react";
+import { useSelector } from "react-redux";
+import PropTypes from "prop-types";
+import Tabs from "@material-ui/core/Tabs";
+import Tab from "@material-ui/core/Tab";
+import Box from "@material-ui/core/Box";
+import { makeStyles, useTheme } from "@material-ui/core/styles";
+import embed from "vega-embed";
+
+const useStyles = makeStyles(() => ({
+  container: { width: "100%" },
+  plotDiv: (props) => ({
+    width: props.width,
+    height: props.height,
+  }),
+}));
+
+const plotSpec = (inputData, color, textColor) => ({
+  $schema: "https://vega.github.io/schema/vega-lite/v4.json",
+  description: "Bar chart of latest ACAI values",
+  width: "container",
+  height: "container",
+  background: "transparent",
+  data: {
+    values: inputData.data,
+  },
+  encoding: {
+    y: {
+      field: "model",
+      type: "nominal",
+      axis: {
+        labelFontSize: "14",
+        titleFontSize: "16",
+        labelColor: textColor,
+        tickColor: textColor,
+        titleColor: textColor,
+      },
+    },
+    x: {
+      field: "score",
+      type: "quantitative",
+      scale: { domain: [0, 1.2] },
+      axis: {
+        labelFontSize: "12",
+        titleFontSize: "16",
+        labelColor: textColor,
+        tickColor: textColor,
+        titleColor: textColor,
+      },
+    },
+  },
+  layer: [
+    {
+      mark: "bar",
+      encoding: {
+        color: { value: color },
+      },
+    },
+    {
+      mark: { type: "text", align: "left", baseline: "middle", dx: 3 },
+      encoding: {
+        text: { field: "score", type: "quantitative" },
+        color: { value: textColor },
+      },
+    },
+  ],
+});
+
+function TabPanel(props) {
+  const { children, value, index, ...other } = props;
+
+  return (
+    <div
+      role="tabpanel"
+      hidden={value !== index}
+      id={`simple-tabpanel-${index}`}
+      aria-labelledby={`simple-tab-${index}`}
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...other}
+    >
+      {value === index && <Box p={3}>{children}</Box>}
+    </div>
+  );
+}
+
+TabPanel.propTypes = {
+  children: PropTypes.node,
+  index: PropTypes.number.isRequired,
+  value: PropTypes.number.isRequired,
+};
+
+TabPanel.defaultProps = {
+  children: null,
+};
+
+const AcaiPlot = ({ width, height }) => {
+  const theme = useTheme();
+  const { annotations } = useSelector((state) => state.source);
+  const classes = useStyles({ width, height });
+  const [value, setValue] = useState(0);
+  const handleChange = (event, newValue) => {
+    setValue(newValue);
+  };
+
+  const acaiAnnotations = annotations?.filter((annotation) => {
+    const acaiOrigins = ["au:hosted", "au-public:hosted", "au-caltech:hosted"];
+    return acaiOrigins.includes(annotation.origin);
+  });
+
+  // Get just the ACAI values
+  const getAcaiValues = ({ acai_b, acai_h, acai_n, acai_o, acai_v }) => [
+    { model: "acai_b", score: acai_b },
+    { model: "acai_h", score: acai_h },
+    { model: "acai_n", score: acai_n },
+    { model: "acai_o", score: acai_o },
+    { model: "acai_v", score: acai_v },
+  ];
+  const plotDatas = acaiAnnotations?.map((annotation) => ({
+    origin: annotation.origin,
+    data: getAcaiValues(annotation.data),
+  }));
+
+  if (plotDatas) {
+    return (
+      <div className={classes.container}>
+        <Tabs
+          value={value}
+          onChange={handleChange}
+          variant="scrollable"
+          scrollButtons="auto"
+          aria-label="simple tabs example"
+        >
+          {plotDatas.map((plotData, i) => (
+            <Tab
+              key={`tab-${plotData.origin}`}
+              label={plotData.origin}
+              id={`simple-tab-${i}`}
+            />
+          ))}
+        </Tabs>
+        <div>
+          {plotDatas.map((plotData, i) => (
+            <TabPanel
+              value={value}
+              index={i}
+              key={`acai-plot-div-${plotData.origin}`}
+              data-testid={`acai-plot-div-${plotData.origin}`}
+            >
+              <div
+                className={classes.plotDiv}
+                ref={(node) => {
+                  if (node) {
+                    embed(
+                      node,
+                      plotSpec(
+                        plotData,
+                        theme.palette.primary.main,
+                        theme.palette.text.primary
+                      ),
+                      {
+                        actions: false,
+                      }
+                    );
+                  }
+                }}
+              />
+            </TabPanel>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return null;
+};
+
+AcaiPlot.propTypes = {
+  width: PropTypes.string,
+  height: PropTypes.string,
+};
+
+AcaiPlot.defaultProps = {
+  width: "300px",
+  height: "150px",
+};
+
+export default AcaiPlot;

--- a/extensions/skyportal/static/js/components/SourceDesktop.jsx
+++ b/extensions/skyportal/static/js/components/SourceDesktop.jsx
@@ -51,6 +51,10 @@ const CentroidPlot = React.lazy(() =>
   import(/* webpackChunkName: "CentroidPlot" */ "./CentroidPlot")
 );
 
+const AcaiPlot = React.lazy(() =>
+  import(/* webpackChunkName: "AcaiPlot" */ "./AcaiPlot")
+);
+
 // Export to allow Candidate.jsx to use styles
 export const useSourceStyles = makeStyles((theme) => ({
   chip: {
@@ -594,6 +598,28 @@ const SourceDesktop = ({ source }) => {
                   className={classes.smallPlot}
                   sourceId={source.id}
                   size={centroidPlotSize}
+                />
+              </Suspense>
+            </AccordionDetails>
+          </Accordion>
+        </div>
+        <div className={classes.columnItem}>
+          <Accordion defaultExpanded>
+            <AccordionSummary
+              expandIcon={<ExpandMoreIcon />}
+              aria-controls="acaiplot-content"
+              id="acaiplot-header"
+            >
+              <Typography className={classes.accordionHeading}>
+                Latest ACAI Values
+              </Typography>
+            </AccordionSummary>
+            <AccordionDetails>
+              <Suspense fallback={<div>Loading ACAI plot...</div>}>
+                <AcaiPlot
+                  className={classes.smallPlot}
+                  width="22.5rem"
+                  height="15rem"
                 />
               </Suspense>
             </AccordionDetails>

--- a/extensions/skyportal/static/js/components/SourceMobile.jsx
+++ b/extensions/skyportal/static/js/components/SourceMobile.jsx
@@ -59,6 +59,10 @@ const CentroidPlot = React.lazy(() =>
   import(/* webpackChunkName: "CentroidPlot" */ "./CentroidPlot")
 );
 
+const AcaiPlot = React.lazy(() =>
+  import(/* webpackChunkName: "AcaiPlot" */ "./AcaiPlot")
+);
+
 export const useSourceStyles = makeStyles((theme) => ({
   chip: {
     margin: theme.spacing(0.5),
@@ -191,6 +195,7 @@ const SourceMobile = WidthProvider(
   withOrientationChange(({ source, isLandscape, width }) => {
     const matches = useMediaQuery("(min-width: 475px)");
     const centroidPlotSize = matches ? "26rem" : "17rem";
+    const acaiPlotSize = matches ? "21rem" : "14rem";
 
     const classes = useSourceStyles();
 
@@ -288,7 +293,11 @@ const SourceMobile = WidthProvider(
                   )}
                   <div className={classes.infoLine}>
                     <div className={classes.sourceInfo}>
-                      <AlertsSearchButton objID={source.id} ra={source.ra} dec={source.dec} />
+                      <AlertsSearchButton
+                        objID={source.id}
+                        ra={source.ra}
+                        dec={source.dec}
+                      />
                     </div>
                   </div>
                   <div className={classes.infoLine}>
@@ -643,6 +652,26 @@ const SourceMobile = WidthProvider(
                   />
                 </Suspense>
               </div>
+            </AccordionDetails>
+          </Accordion>
+          <Accordion defaultExpanded>
+            <AccordionSummary
+              expandIcon={<ExpandMoreIcon />}
+              aria-controls="acaiplot-content"
+              id="acaiplot-header"
+            >
+              <Typography className={classes.accordionHeading}>
+                Latest ACAI Values
+              </Typography>
+            </AccordionSummary>
+            <AccordionDetails>
+              <Suspense fallback={<div>Loading ACAI plot...</div>}>
+                <AcaiPlot
+                  className={classes.smallPlot}
+                  width={acaiPlotSize}
+                  height={`calc(${acaiPlotSize} / 2)`}
+                />
+              </Suspense>
             </AccordionDetails>
           </Accordion>
           <Accordion defaultExpanded>

--- a/extensions/skyportal/static/js/components/SourceMobile.jsx
+++ b/extensions/skyportal/static/js/components/SourceMobile.jsx
@@ -195,6 +195,7 @@ const SourceMobile = WidthProvider(
   withOrientationChange(({ source, isLandscape, width }) => {
     const matches = useMediaQuery("(min-width: 475px)");
     const centroidPlotSize = matches ? "26rem" : "17rem";
+    const hrDiagramSize = matches ? 300 : 200;
     const acaiPlotSize = matches ? "21rem" : "14rem";
 
     const classes = useSourceStyles();
@@ -552,8 +553,8 @@ const SourceMobile = WidthProvider(
                     <Suspense fallback={<div>Loading HR diagram...</div>}>
                       <VegaHR
                         data={source.color_magnitude}
-                        width={300}
-                        height={300}
+                        width={hrDiagramSize}
+                        height={hrDiagramSize}
                         data-testid={`hr_diagram_${source.id}`}
                       />
                     </Suspense>


### PR DESCRIPTION
Adds a (very) basic ACAI values plot to the Source page, simply plotting the latest value found in the loaded source's annotations for each program in a bar chart:
![acai](https://user-images.githubusercontent.com/17696889/127546612-c8acfe88-4b55-4032-adea-8db2251d9db7.gif)

Also brings in the CentroidPlot.jsx and HR diagram styling changes introduced in https://github.com/skyportal/skyportal/pull/2154

Of course, much more could be done with this as future improvements, i.e. querying K for the full series of ACAI values and producing more detailed plots with medians, std dev, etc. This serves more as a basic starting point to get something at least somewhat useful out there. Seems like this should at least address the extent of the functionality in the original feature request.

Closes #247