### PR TITLE
Pin SP - 20210812

### DIFF
--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   test-integration:
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Also increased timeout to 30 minutes in test-integration GA workflow - 25 is not enough anymore now that we test processing two alert streams, ZTF and PGIR. 