### PR TITLE
Use docker.yaml to configure SkyPortal Dockerfile

### DIFF
--- a/extensions/skyportal/docker-compose.skyportal.yaml
+++ b/extensions/skyportal/docker-compose.skyportal.yaml
@@ -11,8 +11,12 @@ services:
     expose:
       - "5000"
     volumes:
-      # fritz takes care of making a docker-appropriate config.yaml with Fritz-specific additions
-      - ${PWD}/../../skyportal/config.yaml:/skyportal/config.yaml
+      # If running the built image, this is unnecessary, since the
+      # docker.yaml is already copied in.  But if you are deploying
+      # locally (and modifying docker.yaml) this may come in handy.
+      #
+      # Note that the fritz build command regenerates docker.yaml
+      - ${PWD}/../../skyportal/docker.yaml:/skyportal/config.yaml
       - ${PWD}/../../skyportal/data/db_fritz.yaml:/skyportal/data/db_seed.yaml
       - thumbnails:/skyportal/static/thumbnails
     labels:

--- a/launcher/commands/doc.py
+++ b/launcher/commands/doc.py
@@ -17,7 +17,7 @@ def doc(yes: bool = False, upload: bool = False):
         subprocess.run(
             [
                 "cp",
-                "config.yaml",
+                "docker.yaml",
                 destination,
             ],
             check=True,

--- a/launcher/commands/run.py
+++ b/launcher/commands/run.py
@@ -1,4 +1,3 @@
-import os
 import pathlib
 import subprocess
 
@@ -17,9 +16,6 @@ def run(
     yes: bool = False,
 ):
     """🚀 Launch Fritz"""
-    env = os.environ.copy()
-    env.update({"FLAGS": "--config=../fritz.yaml"})
-
     if init:
         build(
             init=init,

--- a/launcher/commands/test.py
+++ b/launcher/commands/test.py
@@ -161,7 +161,7 @@ def test():
         "-i",
         "skyportal_web_1",
         "cp",
-        "config.yaml",
+        "docker.yaml",
         "test_config.yaml",
     ]
     try:

--- a/launcher/config.py
+++ b/launcher/config.py
@@ -58,7 +58,7 @@ def check_config(cfg="fritz.defaults.yaml", yes=False):
     config["skyportal"]["database"]["host"] = "db"
     config["skyportal"]["server"]["url"] = "http://localhost:5000"
     config_skyportal = config["skyportal"]  # don't need the K stuff
-    with open("skyportal/config.yaml", "w") as skyportal_config_yaml:
+    with open("skyportal/docker.yaml", "w") as skyportal_config_yaml:
         yaml.dump(config_skyportal, skyportal_config_yaml)
 
     # update fritz.yaml:

--- a/launcher/skyportal.py
+++ b/launcher/skyportal.py
@@ -108,8 +108,3 @@ def patch():
         for line in ext_req:
             if line not in skyportal_req:
                 f.write(line)
-
-    # The skyportal .dockerignore includes config.yaml, but we would like
-    # to add that file; we therefore overwrite the .dockerignore
-    with open("skyportal/.dockerignore", "w") as f:
-        f.write(".*\n")


### PR DESCRIPTION
This is the way the SP Dockerfile was intended to be configured.
Inside, it copies this to config.yaml and then fills out templates and
sets up services.

If `config.yaml` is used instead, like we did in Fritz, it gets
overwritten by `docker.yaml` at some point—no good.