### PR TITLE
added a doc user_APIexamples.md

### DIFF
--- a/doc/user_APIexamples.md
+++ b/doc/user_APIexamples.md
@@ -1,0 +1,14 @@
+# Fritz API examples
+
+[Fritz](https://github.com/fritz-marshal/fritz) has a fully functional API. The documentation 
+for the API can be found [here](https://docs.fritz.science/api.html). To avoid users duplicating code and re-inventing the wheel, here are some examples of how users are using the Fritz-API.
+
+### Tools for the Zwicky Transient Facility (ZTF) Census of the Local Universe (CLU) Experiment
+The CLU team has some tools to download, annotate, and upload sources to Fritz. The code can be found on the [github](https://github.com/AndyTza/ZTF_CLU_Tools/tree/main/scripts) page of Andy Tzanidakis.
+
+### A collection of snippets by Igor Andreoni with Fritz and Kowalksi 
+A few python examples to query Kowalski and upload sources and spectra to Fritz. See the [github](https://github.com/igorandreoni/snippets) page of Igor Andreoni.
+
+
+
+


### PR DESCRIPTION
I added a doc where we can collect links to user-examples. As mentioned, this is to avoid duplication of work; emailing all Fritz users to ask if someone has done something already etc. 

This should be linked to issues #399 