### PR TITLE
prepare config for sncosmo upgrade

### DIFF
--- a/fritz.defaults.yaml
+++ b/fritz.defaults.yaml
@@ -492,17 +492,17 @@ skyportal:
   # length that defines the full Quantum Efficiency at each wavelength.
   # must have at least two elements in the arrays
   # `wavelength` and `transmission`.
-  additional_bandpasses:
-    - name: 'atlasc'
-      filterset: 'atlas'
-      wavelength: [4150, 4157, 6556, 6560]
-      transmission: [0, 1, 1, 0]
-      description: "basic ATLAS C filter - tophat transmission"
-    - name: 'atlaso'
-      filterset: 'atlas'
-      wavelength: [5580, 5582, 8249, 8250]
-      transmission: [0, 1, 1, 0]
-      description: "basic ATLAS O filter - tophat transmission"
+  # additional_bandpasses:
+  #  - name: 'atlasc'
+  #    filterset: 'atlas'
+  #    wavelength: [4150, 4157, 6556, 6560]
+  #    transmission: [0, 1, 1, 0]
+  #    description: "basic ATLAS C filter - tophat transmission"
+  #  - name: 'atlaso'
+  #    filterset: 'atlas'
+  #    wavelength: [5580, 5582, 8249, 8250]
+  #    transmission: [0, 1, 1, 0]
+  #    description: "basic ATLAS O filter - tophat transmission"
 
 kowalski:
   server:


### PR DESCRIPTION
This PR removes the additional_bandpasses bandpasses column given those (correct) bandpasses appear in sncosmo 2.8. To be merged jointly with:
https://github.com/skyportal/skyportal/pull/2763