### PR TITLE
add ztf forced photometry endpoint

### DIFF
--- a/fritz.defaults.yaml
+++ b/fritz.defaults.yaml
@@ -32,6 +32,8 @@ skyportal:
       host: kowalski.caltech.edu
       port: 443
 
+    ztf_forced_endpoint: https://ztfweb.ipac.caltech.edu
+
     swift:
       protocol: https
       host: www.swift.psu.edu


### PR DESCRIPTION
This PR adds the ZTF forced photometry endpoint to the config.