### PR TITLE
Add gcn pages to fritz

### DIFF
--- a/fritz.defaults.yaml
+++ b/fritz.defaults.yaml
@@ -109,6 +109,8 @@ skyportal:
         component: DBStats
       - path: "/gcn_events"
         component: GcnEvents
+      - path: "/gcn_events/:dateobs"
+        component: GcnEventPage
       - path: "/telescopes"
         component: TelescopePage
       - path: "/instruments"


### PR DESCRIPTION
This PR adds the gcn pages to the fritz config.