### PR TITLE
add galaxy to fritz sidebar

### DIFF
--- a/fritz.defaults.yaml
+++ b/fritz.defaults.yaml
@@ -107,6 +107,8 @@ skyportal:
         component: Periodogram
       - path: "/db_stats"
         component: DBStats
+      - path: "/galaxies"
+        component: GalaxyPage
       - path: "/gcn_events"
         component: GcnEvents
       - path: "/gcn_events/:dateobs"
@@ -204,6 +206,10 @@ skyportal:
           - name: Observations
             icon: ZoomInOutlined
             url: /observations
+
+          - name: Galaxies
+            icon: TornadoOutlined
+            url: /galaxies
 
       - name: Admin
         permissions: ["Manage users", "System admin"]


### PR DESCRIPTION
This PR adds the galaxy page to the fritz sidebar.