### PR TITLE
Use newer version of postgres in default compose

### DIFF
--- a/extensions/skyportal/docker-compose.skyportal.yaml
+++ b/extensions/skyportal/docker-compose.skyportal.yaml
@@ -39,7 +39,7 @@ services:
       - db
 
   db:
-    image: postgres:12.2
+    image: postgres:14.4
     environment:
       POSTGRES_USER: skyportal
       POSTGRES_PASSWORD: password


### PR DESCRIPTION
This PR bumps default postgres in docker-compose to 14.4, required for all of the healpix-alchemy infrastructure.