### PR TITLE
Fix Alert user detached from session

### DIFF
--- a/extensions/skyportal/skyportal/handlers/api/alert.py
+++ b/extensions/skyportal/skyportal/handlers/api/alert.py
@@ -221,9 +221,13 @@ class AlertHandler(BaseHandler):
         # allow access to public data only by default
         program_id_selector = {1}
 
-        for stream in self.associated_user_object.streams:
-            if "ztf" in stream.name.lower():
-                program_id_selector.update(set(stream.altdata.get("selector", [])))
+        # using self.Session() should attach the
+        # associated_user_object to the current session
+        # so it can lazy load things like streams
+        with self.Session():
+            for stream in self.associated_user_object.streams:
+                if "ztf" in stream.name.lower():
+                    program_id_selector.update(set(stream.altdata.get("selector", [])))
 
         program_id_selector = list(program_id_selector)
 

--- a/fritz.defaults.yaml
+++ b/fritz.defaults.yaml
@@ -433,6 +433,10 @@ skyportal:
     cosmology: Planck18
     #cosmology: {H0: "65.0", Om0: 0.3, Ode0: 0.7, name: 'skyportal_user_cosmo'}
 
+    # The minimum signal-to-noise ratio/ n-sigma for lim mag cacluations to
+    # consider a photometry point as a detection
+    photometry_detection_threshold_nsigma: 3.0
+
   external_logging:
     papertrail:
       # get an account at https://papertrailapp.com

--- a/fritz.defaults.yaml
+++ b/fritz.defaults.yaml
@@ -17,6 +17,9 @@ skyportal:
     secret_key: abc01234
     factory: skyportal.app_server_fritz.make_app_fritz
 
+    observation_plan:
+      default_filters: [ 'ztfg', 'ztfr', 'ztfi' ]
+
     # this endpoint does not actually do anything -- it is just for testing
     sedm_endpoint: http://minar.caltech.edu/add_fritz
 

--- a/fritz.defaults.yaml
+++ b/fritz.defaults.yaml
@@ -17,9 +17,6 @@ skyportal:
     secret_key: abc01234
     factory: skyportal.app_server_fritz.make_app_fritz
 
-    observation_plan:
-      default_filters: [ 'ztfg', 'ztfr', 'ztfi' ]
-
     # this endpoint does not actually do anything -- it is just for testing
     sedm_endpoint: http://minar.caltech.edu/add_fritz
 
@@ -432,10 +429,6 @@ skyportal:
     # the user-supplied cosmology parameter set constructs the site-wide cosmology.
     cosmology: Planck18
     #cosmology: {H0: "65.0", Om0: 0.3, Ode0: 0.7, name: 'skyportal_user_cosmo'}
-
-    # The minimum signal-to-noise ratio/ n-sigma for lim mag cacluations to
-    # consider a photometry point as a detection
-    photometry_detection_threshold_nsigma: 3.0
 
   external_logging:
     papertrail:


### PR DESCRIPTION
There's a bug when using the alerts handler, when the current user cannot access streams because it is detached form a session. 
I opened a `self.Session` that should attach the current user to the new session and let it load streams. 