### PR TITLE
Add LCO archive endpoint

### DIFF
--- a/fritz.defaults.yaml
+++ b/fritz.defaults.yaml
@@ -27,6 +27,8 @@ skyportal:
     lco_host: observe.lco.global
     lco_port: 443
 
+    lco_archive_endpoint: https://archive-api.lco.global
+
     ztf:
       protocol: https
       host: kowalski.caltech.edu


### PR DESCRIPTION
This PR adds the LCO archive endpoint to the fritz default config.