### PR TITLE
set group_id for GCN

### DIFF
--- a/fritz.defaults.yaml
+++ b/fritz.defaults.yaml
@@ -489,6 +489,8 @@ skyportal:
   gcn:
     server: gcn.nasa.gov
     # you can obtain a client_id and client_secret at https://gcn.nasa.gov/quickstart
+    # you can set a group_id to remember the last GCN the app ingested from the stream
+    group_id:
     client_id:
     client_secret:
     notice_types:

--- a/fritz.defaults.yaml
+++ b/fritz.defaults.yaml
@@ -490,7 +490,7 @@ skyportal:
     server: gcn.nasa.gov
     # you can obtain a client_id and client_secret at https://gcn.nasa.gov/quickstart
     # you can set a group_id to remember the last GCN the app ingested from the stream
-    group_id:
+    client_group_id:
     client_id:
     client_secret:
     notice_types:


### PR DESCRIPTION
This PR allows one to set a group_id for GCN which will remember the last entry committed from the kafka stream. Pairs with https://github.com/skyportal/skyportal/pull/3508.