### PR TITLE
Change Archive -> Persistent Sources in panel

### DIFF
--- a/fritz.defaults.yaml
+++ b/fritz.defaults.yaml
@@ -177,7 +177,7 @@ skyportal:
             icon: Explore
             url: /alerts
 
-          - name: Archive
+          - name: Persistent Sources
             icon: CloudCircle
             url: /archive
 


### PR DESCRIPTION
This PR changes Archive to Persistent Sources in the left panel, which is a much more intuitive name.