### PR TITLE
add alert_available

### DIFF
--- a/extensions/skyportal/skyportal/handlers/api/alert.py
+++ b/extensions/skyportal/skyportal/handlers/api/alert.py
@@ -39,6 +39,8 @@ from .photometry import add_external_photometry
 from .thumbnail import post_thumbnail
 
 
+alert_available = True
+
 env, cfg = load_env()
 log = make_log("alert")
 


### PR DESCRIPTION
This combines with skyportal PR #3534 to allow importing alert.py without a try/catch statement. 