### PR TITLE
Fix case where alert dataframe has no candid

### DIFF
--- a/extensions/skyportal/skyportal/handlers/api/alert.py
+++ b/extensions/skyportal/skyportal/handlers/api/alert.py
@@ -250,7 +250,8 @@ def post_alert(
             alert_data["prv_candidates"].append(latest_alert_data["candidate"])
 
     df = pd.DataFrame.from_records(alert_data["prv_candidates"])
-    mask_candid = df["candid"] == str(candid)
+    mask_candid = df["candid"] == str(candid) if 'candid' in df.columns else []
+
 
     if candid is None or sum(mask_candid) == 0:
         candid = int(latest_alert_data["candidate"]["candid"])


### PR DESCRIPTION
When posting an alert from the `ThumbnailsPathHandler` I get errors where there is no "candid" key in the dataframe returned from `alert_data`. 

I am not sure why this is happening but I can't regenerate the thumbnails this way. 