### PR TITLE
Annotation button plugin to fetch/post SCoPe features from Kowalski/gloria

### DIFF
--- a/extensions/skyportal/skyportal/app_server_fritz.py
+++ b/extensions/skyportal/skyportal/app_server_fritz.py
@@ -13,7 +13,7 @@ from skyportal.handlers.api.archive import (
     ArchiveCatalogsHandler,
     ArchiveHandler,
     CrossMatchHandler,
-    FeaturesHandler,
+    ScopeFeaturesHandler,
 )
 from skyportal.handlers.api.kowalski_filter import KowalskiFilterHandler
 from skyportal.handlers.api.tns_info import TNSInfoHandler
@@ -30,7 +30,7 @@ fritz_handlers = [
     (r"/api/archive", ArchiveHandler),
     (r"/api/archive/catalogs", ArchiveCatalogsHandler),
     (r"/api/archive/cross_match", CrossMatchHandler),
-    (r"/api/archive/features", FeaturesHandler),
+    (r"/api/archive/features", ScopeFeaturesHandler),
     # Alert Stream filter versioning via K:
     (r"/api/filters/([0-9]+)?/v", KowalskiFilterHandler),
     (r"/api/tns_info/(.*)", TNSInfoHandler),

--- a/extensions/skyportal/skyportal/app_server_fritz.py
+++ b/extensions/skyportal/skyportal/app_server_fritz.py
@@ -13,6 +13,7 @@ from skyportal.handlers.api.archive import (
     ArchiveCatalogsHandler,
     ArchiveHandler,
     CrossMatchHandler,
+    FeaturesHandler,
 )
 from skyportal.handlers.api.kowalski_filter import KowalskiFilterHandler
 from skyportal.handlers.api.tns_info import TNSInfoHandler
@@ -29,6 +30,7 @@ fritz_handlers = [
     (r"/api/archive", ArchiveHandler),
     (r"/api/archive/catalogs", ArchiveCatalogsHandler),
     (r"/api/archive/cross_match", CrossMatchHandler),
+    (r"/api/archive/features", FeaturesHandler),
     # Alert Stream filter versioning via K:
     (r"/api/filters/([0-9]+)?/v", KowalskiFilterHandler),
     (r"/api/tns_info/(.*)", TNSInfoHandler),

--- a/extensions/skyportal/skyportal/handlers/api/archive.py
+++ b/extensions/skyportal/skyportal/handlers/api/archive.py
@@ -291,7 +291,7 @@ class CrossMatchHandler(BaseHandler):
             return self.error(response.get("message"))
 
 
-class FeaturesHandler(BaseHandler):
+class ScopeFeaturesHandler(BaseHandler):
     @auth_or_token
     def post(self):
         """

--- a/extensions/skyportal/skyportal/handlers/api/archive.py
+++ b/extensions/skyportal/skyportal/handlers/api/archive.py
@@ -434,18 +434,18 @@ class FeaturesHandler(BaseHandler):
                     "query": {
                         "catalog": catalog,
                         "filter": filter,
-                    },
-                    "$project": {
-                        "_id": 1,
-                        "ra": 1,
-                        "dec": 1,
-                        "filter": 1,
-                        "meanmag": 1,
-                        "vonneumannratio": 1,
-                        "refchi": 1,
-                        "refmag": 1,
-                        "refmagerr": 1,
-                        "iqr": 1,
+                        "projection": {
+                            "_id": 1,
+                            "ra": 1,
+                            "dec": 1,
+                            "filter": 1,
+                            "meanmag": 1,
+                            "vonneumannratio": 1,
+                            "refchi": 1,
+                            "refmag": 1,
+                            "refmagerr": 1,
+                            "iqr": 1,
+                        },
                     },
                 }
 

--- a/extensions/skyportal/skyportal/handlers/api/archive.py
+++ b/extensions/skyportal/skyportal/handlers/api/archive.py
@@ -321,21 +321,22 @@ class ScopeFeaturesHandler(BaseHandler):
             description: Dec. in degrees
           - in: query
             name: catalog
-            required: true
+            required: false
             schema:
               type: str
+            description: default is ZTF_source_features_DR5
           - in: query
             name: radius
-            required: true
+            required: false
             schema:
               type: float
-            description: Max distance from specified (RA, Dec) (capped at 1 deg)
+            description: Max distance from specified (RA, Dec) (capped at 1 deg). Default is 2
           - in: query
             name: radius_units
-            required: true
+            required: false
             schema:
               type: string
-            description: Distance units (either "deg", "arcmin", or "arcsec")
+            description: Distance units (either "deg", "arcmin", or "arcsec"). Default is arcsec
         responses:
           200:
             content:

--- a/extensions/skyportal/skyportal/handlers/api/archive.py
+++ b/extensions/skyportal/skyportal/handlers/api/archive.py
@@ -502,7 +502,6 @@ class ScopeFeaturesHandler(BaseHandler):
 
                         session.add_all(annotations)
 
-                        session.commit()
                         try:
                             session.commit()
                         except IntegrityError:

--- a/extensions/skyportal/skyportal/handlers/api/archive.py
+++ b/extensions/skyportal/skyportal/handlers/api/archive.py
@@ -451,8 +451,8 @@ class FeaturesHandler(BaseHandler):
 
                 response = gloria.query(query=query)
                 if response.get("status", "error") == "success":
-                    light_curves = response.get("data")
-                    return self.success(data=light_curves)
+                    features = response.get("data")
+                    return self.success(data=features)
 
             return self.error(response.get("message"))
 

--- a/extensions/skyportal/skyportal/handlers/api/archive.py
+++ b/extensions/skyportal/skyportal/handlers/api/archive.py
@@ -350,7 +350,9 @@ class FeaturesHandler(BaseHandler):
         available_catalog_names = gloria.query(query=query).get("data")
         # expose only the ZTF features for now
         available_catalogs = [
-            catalog for catalog in available_catalog_names if "ZTF_source_features" in catalog
+            catalog
+            for catalog in available_catalog_names
+            if "ZTF_source_features" in catalog
         ]
 
         catalog = self.get_query_argument("catalog")
@@ -432,19 +434,19 @@ class FeaturesHandler(BaseHandler):
                     "query": {
                         "catalog": catalog,
                         "filter": filter,
-                        },
-                        "$project": {
-                            "_id": 1,
-                            "ra": 1,
-                            "dec": 1,
-                            "filter": 1,
-                            "meanmag": 1,
-                            "vonneumannratio": 1,
-                            "refchi": 1,
-                            "refmag": 1,
-                            "refmagerr": 1,
-                            "iqr": 1,
-                        },
+                    },
+                    "$project": {
+                        "_id": 1,
+                        "ra": 1,
+                        "dec": 1,
+                        "filter": 1,
+                        "meanmag": 1,
+                        "vonneumannratio": 1,
+                        "refchi": 1,
+                        "refmag": 1,
+                        "refmagerr": 1,
+                        "iqr": 1,
+                    },
                 }
 
                 response = gloria.query(query=query)
@@ -453,6 +455,7 @@ class FeaturesHandler(BaseHandler):
                     return self.success(data=light_curves)
 
             return self.error(response.get("message"))
+
 
 class ArchiveHandler(BaseHandler):
     @auth_or_token

--- a/extensions/skyportal/static/js/components/SourceAnnotationButtonsPlugins.jsx
+++ b/extensions/skyportal/static/js/components/SourceAnnotationButtonsPlugins.jsx
@@ -1,0 +1,51 @@
+import React from "react";
+import PropTypes from "prop-types";
+import * as archiveActions from "../ducks/archive";
+
+
+const [isSubmittingAnnotationKowalski, setIsSubmittingAnnotationKowalski] =
+    useState(null);
+  const handleAnnotationKowalski = async (id, ra, dec) => {
+    setIsSubmittingAnnotationKowalski(id);
+    await dispatch(archiveActions.fetchKowalskiFeatures(ra, dec));
+    await dispatch(archiveActions.postKowalskiFeatures(id));
+    setIsSubmittingAnnotationKowalski(null);
+  };
+
+ const SourceAnnotationButtonPlugins = ({source}) => 
+{
+     return (
+    <>
+        {isSubmittingAnnotationKowalski === source.id ? (
+        <div>
+        <CircularProgress />
+        </div>
+    ) : (
+        <Button
+        secondary
+        onClick={() => {
+            handleAnnotationKowalski(source.id, source.ra, source.dec);
+        }}
+        size="small"
+        type="submit"
+        data-testid={`kowalskiRequest_${source.id}`}
+        >
+        KOWALSKI
+        </Button>
+    )};
+    </>
+    );
+    };
+    
+
+SourceAnnotationButtonPlugins.propTypes = {
+    source: PropTypes.shape({
+        id: PropTypes.string.isRequired,
+        ra: PropTypes.number.isRequired,
+        dec: PropTypes.number.isRequired,
+    }).isRequired,
+    };
+
+ export default SourceAnnotationButtonPlugins;
+
+

--- a/extensions/skyportal/static/js/components/SourceAnnotationButtonsPlugins.jsx
+++ b/extensions/skyportal/static/js/components/SourceAnnotationButtonsPlugins.jsx
@@ -7,8 +7,7 @@ const [isSubmittingAnnotationKowalski, setIsSubmittingAnnotationKowalski] =
     useState(null);
   const handleAnnotationKowalski = async (id, ra, dec) => {
     setIsSubmittingAnnotationKowalski(id);
-    await dispatch(archiveActions.fetchKowalskiFeatures(ra, dec));
-    await dispatch(archiveActions.postKowalskiFeatures(id));
+    await dispatch(sourceActions.fetchKowalskiFeatures({id, ra, dec}));
     setIsSubmittingAnnotationKowalski(null);
   };
 

--- a/extensions/skyportal/static/js/components/SourceAnnotationButtonsPlugins.jsx
+++ b/extensions/skyportal/static/js/components/SourceAnnotationButtonsPlugins.jsx
@@ -12,7 +12,7 @@ const [isSubmittingAnnotationKowalski, setIsSubmittingAnnotationKowalski] =
     setIsSubmittingAnnotationKowalski(null);
   };
 
- const SourceAnnotationButtonPlugins = ({source}) => 
+ const SourceAnnotationButtonPlugins = ({source}) =>
 {
      return (
     <>
@@ -36,7 +36,7 @@ const [isSubmittingAnnotationKowalski, setIsSubmittingAnnotationKowalski] =
     </>
     );
     };
-    
+
 
 SourceAnnotationButtonPlugins.propTypes = {
     source: PropTypes.shape({
@@ -47,5 +47,3 @@ SourceAnnotationButtonPlugins.propTypes = {
     };
 
  export default SourceAnnotationButtonPlugins;
-
-

--- a/extensions/skyportal/static/js/components/SourceAnnotationButtonsPlugins.jsx
+++ b/extensions/skyportal/static/js/components/SourceAnnotationButtonsPlugins.jsx
@@ -3,19 +3,19 @@ import PropTypes from "prop-types";
 import * as archiveActions from "../ducks/archive";
 
 
-const [isSubmittingAnnotationKowalski, setIsSubmittingAnnotationKowalski] =
+const [isSubmittingAnnotationScopeFeatures, setIsSubmittingAnnotationScopeFeatures] =
     useState(null);
-  const handleAnnotationKowalski = async (id, ra, dec) => {
-    setIsSubmittingAnnotationKowalski(id);
-    await dispatch(sourceActions.fetchKowalskiFeatures({id, ra, dec}));
-    setIsSubmittingAnnotationKowalski(null);
+  const handleAnnotationScopeFeatures = async (id, ra, dec) => {
+    setIsSubmittingAnnotationScopeFeatures(id);
+    await dispatch(archiveActions.fetchScopeFeatures({id, ra, dec}));
+    setIsSubmittingAnnotationScopeFeatures(null);
   };
 
  const SourceAnnotationButtonPlugins = ({source}) =>
 {
      return (
     <>
-        {isSubmittingAnnotationKowalski === source.id ? (
+        {isSubmittingAnnotationScopeFeatures === source.id ? (
         <div>
         <CircularProgress />
         </div>
@@ -23,13 +23,13 @@ const [isSubmittingAnnotationKowalski, setIsSubmittingAnnotationKowalski] =
         <Button
         secondary
         onClick={() => {
-            handleAnnotationKowalski(source.id, source.ra, source.dec);
+            handleAnnotationScopeFeatures(source.id, source.ra, source.dec);
         }}
         size="small"
         type="submit"
-        data-testid={`kowalskiRequest_${source.id}`}
+        data-testid={`scopeFeaturesRequest_${source.id}`}
         >
-        KOWALSKI
+        SCoPe Features
         </Button>
     )};
     </>

--- a/extensions/skyportal/static/js/components/SourceAnnotationButtonsPlugins.jsx
+++ b/extensions/skyportal/static/js/components/SourceAnnotationButtonsPlugins.jsx
@@ -1,19 +1,25 @@
-import React from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types";
-import * as archiveActions from "../ducks/archive";
+import { useDispatch } from "react-redux";
 
+import CircularProgress from "@mui/material/CircularProgress";
+import Button from "./Button";
 
-const [isSubmittingAnnotationScopeFeatures, setIsSubmittingAnnotationScopeFeatures] =
-    useState(null);
-  const handleAnnotationScopeFeatures = async (id, ra, dec) => {
-    setIsSubmittingAnnotationScopeFeatures(id);
-    await dispatch(archiveActions.fetchScopeFeatures({id, ra, dec}));
-    setIsSubmittingAnnotationScopeFeatures(null);
-  };
+import * as sourceActions from "../ducks/source";
 
- const SourceAnnotationButtonPlugins = ({source}) =>
+const SourceAnnotationButtonPlugins = ({source}) =>
 {
-     return (
+    const dispatch = useDispatch();
+
+    const [isSubmittingAnnotationScopeFeatures, setIsSubmittingAnnotationScopeFeatures] =
+        useState(null);
+    const handleAnnotationScopeFeatures = async (id, ra, dec) => {
+        setIsSubmittingAnnotationScopeFeatures(id);
+        await dispatch(sourceActions.fetchScopeFeatures({id, ra, dec}));
+        setIsSubmittingAnnotationScopeFeatures(null);
+    };
+
+    return (
     <>
         {isSubmittingAnnotationScopeFeatures === source.id ? (
         <div>
@@ -31,7 +37,7 @@ const [isSubmittingAnnotationScopeFeatures, setIsSubmittingAnnotationScopeFeatur
         >
         SCoPe Features
         </Button>
-    )};
+    )}
     </>
     );
     };

--- a/extensions/skyportal/static/js/ducks/archive.js
+++ b/extensions/skyportal/static/js/ducks/archive.js
@@ -82,7 +82,7 @@ export const fetchKowalskiFeatures = (ra, dec, radius = 2, catalog = "ZTF_source
   API.GET(`/api/archive/features?catalog=${catalog}&ra=${ra}&dec=${dec}&radius=${radius}&radius_units=arcsec`, FETCH_KOWALSKI_FEATURES, {
     catalog,
   });
-  
+
 export const postKowalskiFeatures = (sourceID) =>
   API.POST(`/api/sources/${sourceID}/annotations/kowalski`, POST_KOWALSKI_FEATURES);
 

--- a/extensions/skyportal/static/js/ducks/archive.js
+++ b/extensions/skyportal/static/js/ducks/archive.js
@@ -6,6 +6,13 @@ const FETCH_CATALOG_NAMES_OK = "skyportal/FETCH_CATALOG_NAMES_OK";
 const FETCH_CATALOG_NAMES_ERROR = "skyportal/FETCH_CATALOG_NAMES_ERROR";
 const FETCH_CATALOG_NAMES_FAIL = "skyportal/FETCH_CATALOG_NAMES_FAIL";
 
+const FETCH_KOWALSKI_FEATURES = "skyportal/FETCH_KOWALSKI_FEATURES";
+const FETCH_KOWALSKI_FEATURES_OK = "skyportal/FETCH_KOWALSKI_FEATURES_OK";
+const FETCH_KOWALSKI_FEATURES_ERROR = "skyportal/FETCH_KOWALSKI_FEATURES_ERROR";
+const FETCH_KOWALSKI_FEATURES_FAIL = "skyportal/FETCH_KOWALSKI_FEATURES_FAIL";
+
+const POST_KOWALSKI_FEATURES = "skyportal/POST_KOWALSKI_FEATURES";
+
 const FETCH_ZTF_LIGHT_CURVES = "skyportal/FETCH_ZTF_LIGHT_CURVES";
 const FETCH_ZTF_LIGHT_CURVES_OK = "skyportal/FETCH_ZTF_LIGHT_CURVES_OK";
 const FETCH_ZTF_LIGHT_CURVES_ERROR = "skyportal/FETCH_ZTF_LIGHT_CURVES_ERROR";
@@ -70,6 +77,14 @@ export const fetchZTFLightCurves = ({ catalog, ra, dec, radius }) => API.GET(
   `/api/archive?catalog=${catalog}&ra=${ra}&dec=${dec}&radius=${radius}&radius_units=arcsec`,
   FETCH_ZTF_LIGHT_CURVES
 )
+
+export const fetchKowalskiFeatures = (ra, dec, radius = 2, catalog = "ZTF_source_features_DR5") =>
+  API.GET(`/api/archive/features?catalog=${catalog}&ra=${ra}&dec=${dec}&radius=${radius}&radius_units=arcsec`, FETCH_KOWALSKI_FEATURES, {
+    catalog,
+  });
+  
+export const postKowalskiFeatures = (sourceID) =>
+  API.POST(`/api/sources/${sourceID}/annotations/kowalski`, POST_KOWALSKI_FEATURES);
 
 export function saveLightCurves(payload) {
   return API.POST(`/api/archive`, SAVE_LIGHT_CURVES, payload);

--- a/extensions/skyportal/static/js/ducks/archive.js
+++ b/extensions/skyportal/static/js/ducks/archive.js
@@ -11,8 +11,6 @@ const FETCH_KOWALSKI_FEATURES_OK = "skyportal/FETCH_KOWALSKI_FEATURES_OK";
 const FETCH_KOWALSKI_FEATURES_ERROR = "skyportal/FETCH_KOWALSKI_FEATURES_ERROR";
 const FETCH_KOWALSKI_FEATURES_FAIL = "skyportal/FETCH_KOWALSKI_FEATURES_FAIL";
 
-const POST_KOWALSKI_FEATURES = "skyportal/POST_KOWALSKI_FEATURES";
-
 const FETCH_ZTF_LIGHT_CURVES = "skyportal/FETCH_ZTF_LIGHT_CURVES";
 const FETCH_ZTF_LIGHT_CURVES_OK = "skyportal/FETCH_ZTF_LIGHT_CURVES_OK";
 const FETCH_ZTF_LIGHT_CURVES_ERROR = "skyportal/FETCH_ZTF_LIGHT_CURVES_ERROR";
@@ -82,6 +80,22 @@ export const fetchKowalskiFeatures = (params) =>
    API.POST(`/api/archive/features`, FETCH_KOWALSKI_FEATURES, params
    );
 
+const reducerKowalskiFeatures = (state = null, action) => {
+    switch (action.type) {
+      case FETCH_KOWALSKI_FEATURES_OK: {
+        return action.data;
+      }
+      case FETCH_KOWALSKI_FEATURES_ERROR: {
+        return action.message;
+      }
+      case FETCH_KOWALSKI_FEATURES_FAIL: {
+        return "uncaught error";
+      }
+      default:
+        return state;
+    }
+  };
+
 export function saveLightCurves(payload) {
   return API.POST(`/api/archive`, SAVE_LIGHT_CURVES, payload);
 }
@@ -143,4 +157,5 @@ const reducerNearestSources = (state = null, action) => {
 store.injectReducer("catalog_names", reducerCatalogNames);
 store.injectReducer("cross_matches", reducerCrossMatches);
 store.injectReducer("ztf_light_curves", reducer);
+store.injectReducer("kowalski_features", reducerKowalskiFeatures);
 store.injectReducer("nearest_sources", reducerNearestSources);

--- a/extensions/skyportal/static/js/ducks/archive.js
+++ b/extensions/skyportal/static/js/ducks/archive.js
@@ -78,12 +78,9 @@ export const fetchZTFLightCurves = ({ catalog, ra, dec, radius }) => API.GET(
   FETCH_ZTF_LIGHT_CURVES
 )
 
-export const fetchKowalskiFeatures = (ra, dec, radius = 2, radius_units='arcsec', catalog = "ZTF_source_features_DR5") =>
-  API.GET(`/api/archive/features?catalog=${catalog}&ra=${ra}&dec=${dec}&radius=${radius}&radius_units=${radius_units}`, FETCH_KOWALSKI_FEATURES
-  );
-
-// export const postKowalskiFeatures = (sourceID, payload) =>
-//   API.POST(`/api/sources/${sourceID}/annotations/kowalski`, POST_KOWALSKI_FEATURES, payload);
+export const fetchKowalskiFeatures = (params) =>
+   API.POST(`/api/archive/features`, FETCH_KOWALSKI_FEATURES, params
+   );
 
 export function saveLightCurves(payload) {
   return API.POST(`/api/archive`, SAVE_LIGHT_CURVES, payload);

--- a/extensions/skyportal/static/js/ducks/archive.js
+++ b/extensions/skyportal/static/js/ducks/archive.js
@@ -78,13 +78,12 @@ export const fetchZTFLightCurves = ({ catalog, ra, dec, radius }) => API.GET(
   FETCH_ZTF_LIGHT_CURVES
 )
 
-export const fetchKowalskiFeatures = (ra, dec, radius = 2, catalog = "ZTF_source_features_DR5") =>
-  API.GET(`/api/archive/features?catalog=${catalog}&ra=${ra}&dec=${dec}&radius=${radius}&radius_units=arcsec`, FETCH_KOWALSKI_FEATURES, {
-    catalog,
-  });
+export const fetchKowalskiFeatures = (ra, dec, radius = 2, radius_units='arcsec', catalog = "ZTF_source_features_DR5") =>
+  API.GET(`/api/archive/features?catalog=${catalog}&ra=${ra}&dec=${dec}&radius=${radius}&radius_units=${radius_units}`, FETCH_KOWALSKI_FEATURES
+  );
 
-export const postKowalskiFeatures = (sourceID) =>
-  API.POST(`/api/sources/${sourceID}/annotations/kowalski`, POST_KOWALSKI_FEATURES);
+// export const postKowalskiFeatures = (sourceID, payload) =>
+//   API.POST(`/api/sources/${sourceID}/annotations/kowalski`, POST_KOWALSKI_FEATURES, payload);
 
 export function saveLightCurves(payload) {
   return API.POST(`/api/archive`, SAVE_LIGHT_CURVES, payload);

--- a/extensions/skyportal/static/js/ducks/archive.js
+++ b/extensions/skyportal/static/js/ducks/archive.js
@@ -6,10 +6,10 @@ const FETCH_CATALOG_NAMES_OK = "skyportal/FETCH_CATALOG_NAMES_OK";
 const FETCH_CATALOG_NAMES_ERROR = "skyportal/FETCH_CATALOG_NAMES_ERROR";
 const FETCH_CATALOG_NAMES_FAIL = "skyportal/FETCH_CATALOG_NAMES_FAIL";
 
-const FETCH_KOWALSKI_FEATURES = "skyportal/FETCH_KOWALSKI_FEATURES";
-const FETCH_KOWALSKI_FEATURES_OK = "skyportal/FETCH_KOWALSKI_FEATURES_OK";
-const FETCH_KOWALSKI_FEATURES_ERROR = "skyportal/FETCH_KOWALSKI_FEATURES_ERROR";
-const FETCH_KOWALSKI_FEATURES_FAIL = "skyportal/FETCH_KOWALSKI_FEATURES_FAIL";
+const FETCH_SCOPE_FEATURES = "skyportal/FETCH_SCOPE_FEATURES";
+const FETCH_SCOPE_FEATURES_OK = "skyportal/FETCH_SCOPE_FEATURES_OK";
+const FETCH_SCOPE_FEATURES_ERROR = "skyportal/FETCH_SCOPE_FEATURES_ERROR";
+const FETCH_SCOPE_FEATURES_FAIL = "skyportal/FETCH_SCOPE_FEATURES_FAIL";
 
 const FETCH_ZTF_LIGHT_CURVES = "skyportal/FETCH_ZTF_LIGHT_CURVES";
 const FETCH_ZTF_LIGHT_CURVES_OK = "skyportal/FETCH_ZTF_LIGHT_CURVES_OK";
@@ -76,19 +76,19 @@ export const fetchZTFLightCurves = ({ catalog, ra, dec, radius }) => API.GET(
   FETCH_ZTF_LIGHT_CURVES
 )
 
-export const fetchKowalskiFeatures = (params) =>
-   API.POST(`/api/archive/features`, FETCH_KOWALSKI_FEATURES, params
+export const fetchScopeFeatures = (params) =>
+   API.POST(`/api/archive/features`, FETCH_SCOPE_FEATURES, params
    );
 
-const reducerKowalskiFeatures = (state = null, action) => {
+const reducerScopeFeatures = (state = null, action) => {
     switch (action.type) {
-      case FETCH_KOWALSKI_FEATURES_OK: {
+      case FETCH_SCOPE_FEATURES_OK: {
         return action.data;
       }
-      case FETCH_KOWALSKI_FEATURES_ERROR: {
+      case FETCH_SCOPE_FEATURES_ERROR: {
         return action.message;
       }
-      case FETCH_KOWALSKI_FEATURES_FAIL: {
+      case FETCH_SCOPE_FEATURES_FAIL: {
         return "uncaught error";
       }
       default:
@@ -157,5 +157,5 @@ const reducerNearestSources = (state = null, action) => {
 store.injectReducer("catalog_names", reducerCatalogNames);
 store.injectReducer("cross_matches", reducerCrossMatches);
 store.injectReducer("ztf_light_curves", reducer);
-store.injectReducer("kowalski_features", reducerKowalskiFeatures);
+store.injectReducer("scope_features", reducerScopeFeatures);
 store.injectReducer("nearest_sources", reducerNearestSources);


### PR DESCRIPTION
This PR adds an annotation button plugin to fetch SCoPe-generated features from the `ZTF_source_features_DR5` catalog on gloria. The code performs a 2-arcsec cone search around the source's RA and Dec before querying gloria for a set of features. These features, which are then posted to the source as annotations, consist of all the light curve's 'basic stats' along with the ID, field, ccd and quadrant. The current code runs successfully but has the following limitations:

- The single-button nature of the frontend interaction does not permit the user to specify the feature catalog, cone search radius, or specific features to get
- A source can have multiple associated light curves, but since SCoPe features are generated on a per-lightcurve basis, the code currently only gets features from the first `_id` returned from the cone search. 
