### PR TITLE
More connections allowed in pool (db engine args)

### DIFF
--- a/fritz.defaults.yaml
+++ b/fritz.defaults.yaml
@@ -416,6 +416,7 @@ skyportal:
     port: 5432
     user: skyportal
     password: password
+    engine_args: {max_overflow: 30, pool_size: 20}
 
   ports:
     facility_queue: 64510


### PR DESCRIPTION
As suggested by @profjsb, we never use more than 1/3 of the max nb of connections to the database. Here, we try to allow more connections at once to prevent the frontend apps from filling up the pool and timing out too quickly.