### PR TITLE
Penquins 2.3.1 + SkyPortal 893af747e1b4290e23266b093f883a0d343cf122

### DIFF
--- a/.requirements/ext.txt
+++ b/.requirements/ext.txt
@@ -1,2 +1,2 @@
-penquins>=2.1.0
+penquins>=2.3.1
 pymongo>=3.10.1

--- a/extensions/skyportal/skyportal/handlers/api/alert.py
+++ b/extensions/skyportal/skyportal/handlers/api/alert.py
@@ -229,8 +229,8 @@ def post_alert(
     }
 
     response = kowalski.query(query=query)
-    if response.get("status", "error") == "success":
-        alert_data = response.get("data")
+    if response.get("default").get("status", "error") == "success":
+        alert_data = response.get("default").get("data")
         if len(alert_data) > 0:
             alert_data = alert_data[0]
         else:
@@ -274,8 +274,8 @@ def post_alert(
     }
 
     response = kowalski.query(query=query)
-    if response.get("status", "error") == "success":
-        latest_alert_data = response.get("data")
+    if response.get("default").get("status", "error") == "success":
+        latest_alert_data = response.get("default").get("data")
         if len(latest_alert_data) > 0:
             latest_alert_data = latest_alert_data[0]
     else:
@@ -505,8 +505,8 @@ def post_alert(
         }
 
         response = kowalski.query(query=query)
-        if response.get("status", "error") == "success":
-            cutout = response.get("data", list(dict()))
+        if response.get("default").get("status", "error") == "success":
+            cutout = response.get("default").get("data", list(dict()))
             if len(cutout) > 0:
                 cutout = cutout[0]
             else:
@@ -578,8 +578,8 @@ def get_alerts_by_id(
 
     response = kowalski.query(query=query)
 
-    if response.get("status", "error") == "success":
-        return response.get("data")
+    if response.get("default").get("status", "error") == "success":
+        return response.get("default").get("data")
     else:
         return None
 
@@ -624,8 +624,8 @@ def get_alerts_by_ids(
 
     response = kowalski.query(query=query)
 
-    if response.get("status", "error") == "success":
-        alert_data = response.get("data")
+    if response.get("default").get("status", "error") == "success":
+        alert_data = response.get("default").get("data")
         return alert_data
     else:
         return None
@@ -717,8 +717,8 @@ def get_alerts_by_position(
 
     response = kowalski.query(query=query)
 
-    if response.get("status", "error") == "success":
-        alert_data = response.get("data")
+    if response.get("default").get("status", "error") == "success":
+        alert_data = response.get("default").get("data")
         return alert_data["ZTF_alerts"]["query_coords"]
     else:
         return None
@@ -1116,8 +1116,8 @@ class AlertAuxHandler(BaseHandler):
 
             response = kowalski.query(query=query)
 
-            if response.get("status", "error") == "success":
-                alert_data = response.get("data")
+            if response.get("default").get("status", "error") == "success":
+                alert_data = response.get("default").get("data")
                 if len(alert_data) > 0:
                     alert_data = alert_data[0]
                 else:
@@ -1126,7 +1126,7 @@ class AlertAuxHandler(BaseHandler):
                     self.finish()
                     return
             else:
-                return self.error(response.get("message"))
+                return self.error(response.get("default").get("message"))
 
             # grab and append most recent candid as it should not be in prv_candidates
             query = {
@@ -1172,8 +1172,8 @@ class AlertAuxHandler(BaseHandler):
 
             response = kowalski.query(query=query)
 
-            if response.get("status", "error") == "success":
-                latest_alert_data = response.get("data", list(dict()))
+            if response.get("default").get("status", "error") == "success":
+                latest_alert_data = response.get("default").get("data", list(dict()))
                 if len(latest_alert_data) > 0:
                     latest_alert_data = latest_alert_data[0]
                 else:
@@ -1182,7 +1182,7 @@ class AlertAuxHandler(BaseHandler):
                     self.finish()
                     return
             else:
-                return self.error(response.get("message"))
+                return self.error(response.get("default").get("message"))
 
             candids = {a.get("candid", None) for a in alert_data["prv_candidates"]}
             if latest_alert_data["candidate"]["candid"] not in candids:
@@ -1243,8 +1243,8 @@ class AlertAuxHandler(BaseHandler):
 
             response = kowalski.query(query=query)
 
-            if response.get("status", "error") == "success":
-                tns_data = response.get("data").get("TNS").get(object_id)
+            if response.get("default").get("status", "error") == "success":
+                tns_data = response.get("default").get("data").get("TNS").get(object_id)
                 alert_data["cross_matches"]["TNS"] = tns_data
 
             if not include_prv_candidates:
@@ -1404,8 +1404,8 @@ class AlertCutoutHandler(BaseHandler):
 
             response = kowalski.query(query=query)
 
-            if response.get("status", "error") == "success":
-                alert = response.get("data", [dict()])[0]
+            if response.get("default").get("status", "error") == "success":
+                alert = response.get("default").get("data", [dict()])[0]
             else:
                 return self.error("No cutout found.")
 
@@ -1556,8 +1556,8 @@ class AlertTripletsHandler(BaseHandler):
 
             response = kowalski.query(query=query)
 
-            if response.get("status", "error") == "success":
-                alerts = response.get("data", [dict()])
+            if response.get("default").get("status", "error") == "success":
+                alerts = response.get("default").get("data", [dict()])
             else:
                 return self.error("No cutout found.")
 

--- a/extensions/skyportal/skyportal/handlers/api/db_stats.py
+++ b/extensions/skyportal/skyportal/handlers/api/db_stats.py
@@ -181,7 +181,7 @@ class StatsHandler(BaseHandler):
                     },
                 }
                 response = kowalski.query(query=query_tns_count)
-                data["Number of objects in TNS collection"] = response.get("data")
+                data["Number of objects in TNS collection"] = response.get("default").get("data")
 
                 query_tns_latest_object = {
                     "query_type": "find",
@@ -193,7 +193,7 @@ class StatsHandler(BaseHandler):
                     "kwargs": {"sort": [("discovery_date", -1)], "limit": 1},
                 }
                 response = kowalski.query(query=query_tns_latest_object)
-                response_data = response.get("data", [])
+                response_data = response.get("default").get("data", [])
                 latest_tns_object_discovery_date = (
                     response_data[0]["discovery_date_(ut)"]
                     if len(response_data) > 0
@@ -223,7 +223,7 @@ class StatsHandler(BaseHandler):
                     response = kowalski.query(query=query_alerts_count)
                     data[
                         f"Number of {survey} alerts ingested yesterday (UTC)"
-                    ] = response.get("data")
+                    ] = response.get("default").get("data")
 
                     query_alerts_count = {
                         "query_type": "count_documents",
@@ -239,7 +239,7 @@ class StatsHandler(BaseHandler):
                     response = kowalski.query(query=query_alerts_count)
                     data[
                         f"Number of {survey} alerts ingested since 0h UTC today"
-                    ] = response.get("data")
+                    ] = response.get("default").get("data")
             except Exception as e:
                 log(f"kowalski stats query failed: {str(e)}")
 

--- a/fritz.defaults.yaml
+++ b/fritz.defaults.yaml
@@ -1651,7 +1651,7 @@ kowalski:
 
   misc:
     broker: True
-    supported_penquins_versions: ["2.0.0", "2.0.1", "2.0.2", "2.1.0", "2.1.1"]
+    supported_penquins_versions: ["2.0.0", "2.0.1", "2.0.2", "2.1.0", "2.1.1", "2.2.1", "2.3.1"]
     query_expiration_interval: 5
     max_time_ms: 300000
     max_retries: 100


### PR DESCRIPTION
Needs https://github.com/skyportal/skyportal/pull/4349 to be merged first.
I suggest really trying out the code for this one, there's a lot that could break :)

Locally, I tried each handler and everything seems to work just fine, I can:
- Get alerts from the alerts page
- Visualize individual alerts and save them as as sources from the alerts page
- Get lightcurves from the persistent sources page, where we can now query gloria + melman (meaning DR5 but also now DR16)
- Save lightcurves as sources
- From the source page, get crossmatches with gloria + melman and see them on the centroid plot.
- From the source page, request scope features to be posted as annotations (from ztf features DR5 for now, but can be easily extended to any catalogs with DR`X` in a following PR (or migrated to ztf features DR16 once Brian uploads it to melman or gloria).