### PR TITLE
Persistent sources and Scope features interaction: Improvements

### DIFF
--- a/extensions/skyportal/skyportal/handlers/api/archive.py
+++ b/extensions/skyportal/skyportal/handlers/api/archive.py
@@ -52,7 +52,7 @@ try:
         kowalski = None
         raise Exception("No Kowalski instances available")
 except Exception as e:
-    log(f"Kowalski connection failed: {str(e)}")
+    log(f"Kowalski connection(s) failed: {str(e)}")
     kowalski = None
 
 

--- a/extensions/skyportal/skyportal/handlers/api/archive.py
+++ b/extensions/skyportal/skyportal/handlers/api/archive.py
@@ -49,7 +49,7 @@ try:
                 failed_instances.append(instance_name)
             else:
                 break
-        except:
+        except Exception:
             failed_instances.append(instance_name)
             continue
     if kowalski is not None:
@@ -74,7 +74,6 @@ except Exception as e:
 if kowalski is not None and len(failed_instances) > 0:
     failed_instances = list(set(failed_instances))
     log(f"Failed to connect to some of the Kowalski instance(s): {failed_instances}")
-
 
 
 def flatten_dict_to_list(d):

--- a/extensions/skyportal/skyportal/handlers/api/archive.py
+++ b/extensions/skyportal/skyportal/handlers/api/archive.py
@@ -24,36 +24,57 @@ log = make_log("archive")
 
 instances = {
     "gloria": {
+        **cfg.get("app.gloria", {}),
         "name": "gloria",
-        "protocol": cfg["app.gloria.protocol"],
-        "host": cfg["app.gloria.host"],
-        "port": cfg["app.gloria.port"],
-        "token": cfg["app.gloria.token"],
         "timeout": 10,
     },
     "melman": {
+        **cfg.get("app.melman", {}),
         "name": "melman",
-        "protocol": cfg["app.melman.protocol"],
-        "host": cfg["app.melman.host"],
-        "port": cfg["app.melman.port"],
-        "token": cfg["app.melman.token"],
         "timeout": 10,
     },
 }
 
+# to make sure that we don't block the access to all instances as soon as one of them is not available,
+# we try adding them to the Kowalski class one by one.
+kowalski = None
+failed_instances = []
 try:
-    kowalski = Kowalski(instances=instances, verbose=False)
-    for instance in kowalski.instances.keys():
-        connection_ok = kowalski.ping(instance)
-        log(f"{instance} connection OK: {connection_ok}")
-        if not connection_ok:
-            kowalski.remove(instance)
-    if len(kowalski.instances) == 0:
-        kowalski = None
-        raise Exception("No Kowalski instances available")
+    for instance_name, instance_data in instances.items():
+        try:
+            kowalski = Kowalski(instances={instance_name: instance_data})
+            connection_ok = kowalski.ping(instance_name)
+            if not connection_ok:
+                kowalski = None
+                failed_instances.append(instance_name)
+            else:
+                break
+        except:
+            failed_instances.append(instance_name)
+            continue
+    if kowalski is not None:
+        for instance_name, instance_data in instances.items():
+            if instance_name not in kowalski.instances.keys():
+                try:
+                    kowalski.add(instance_name, instance_data)
+                    connection_ok = kowalski.ping(instance_name)
+                    if not connection_ok:
+                        try:
+                            kowalski.remove(instance_name)
+                        except ValueError:
+                            pass
+                        failed_instances.append(instance_name)
+                except Exception:
+                    failed_instances.append(instance_name)
+                    continue
 except Exception as e:
-    log(f"Kowalski connection(s) failed: {str(e)}")
+    log(f"Could not connect to any of the Kowalski instances: {str(e)}")
     kowalski = None
+
+if kowalski is not None and len(failed_instances) > 0:
+    failed_instances = list(set(failed_instances))
+    log(f"Failed to connect to some of the Kowalski instance(s): {failed_instances}")
+
 
 
 def flatten_dict_to_list(d):
@@ -407,7 +428,6 @@ class ScopeFeaturesHandler(BaseHandler):
         ra = data.pop("ra")
         dec = data.pop("dec")
         catalog = data.pop("catalog", "ZTF_source_features_DR5")
-
         radius = data.pop("radius", 2)
         radius_units = data.pop("radius_units", "arcsec")
 
@@ -511,7 +531,7 @@ class ScopeFeaturesHandler(BaseHandler):
 
                 light_curve_ids = [item["_id"] for item in data[catalog]]
                 if len(light_curve_ids) == 0:
-                    return self.success(data=[])
+                    return self.error("No SCoPe features available.")
 
                 # return features for the first ID
                 filter = {"_id": {"$in": [light_curve_ids[0]]}}
@@ -564,7 +584,6 @@ class ScopeFeaturesHandler(BaseHandler):
                 if failed_instances == len(response) or len(list(features.keys())) == 0:
                     return self.error("Could not find features on any instance.")
 
-                annotations = []
                 annotation_data = {}
                 for key in features.keys():
                     value = features[key]
@@ -582,12 +601,10 @@ class ScopeFeaturesHandler(BaseHandler):
                         groups=groups,
                     )
 
-                    annotations.append(annotation)
-
-                if len(annotations) == 0:
+                if len(annotation_data.keys()) == 0:
                     return self.error("No SCoPe features available.")
 
-                session.add_all(annotations)
+                session.add(annotation)
 
                 try:
                     session.commit()

--- a/extensions/skyportal/static/js/components/Archive.jsx
+++ b/extensions/skyportal/static/js/components/Archive.jsx
@@ -237,7 +237,7 @@ const Archive = () => {
     if (!catalogNames) fetchCatalogNames();
   }, [catalogNames, dispatch, catalogNamesLoadError]);
 
-  const ZTFLightCurveCatalogNames = Array.isArray(catalogNames) ? catalogNames?.filter((name) => name.indexOf('ZTF_sources') !== -1) : null;
+  const ZTFLightCurveCatalogNames = Array.isArray(catalogNames) ? catalogNames?.filter((name) => name.indexOf('ZTF_sources_202') !== -1) : null;
 
   const { lightCurves: ztf_light_curves, queryInProgress } = useSelector((state) => state.ztf_light_curves);
 

--- a/extensions/skyportal/static/js/components/ArchiveSearchButton.jsx
+++ b/extensions/skyportal/static/js/components/ArchiveSearchButton.jsx
@@ -20,7 +20,7 @@ const ArchiveSearchButton = ({ ra, dec, radius = 3 }) => {
     }
   }, [catalogNames, dispatch]);
 
-  const ZTFLightCurveCatalogNames = Array.isArray(catalogNames) ? catalogNames?.filter((name) => name.indexOf('ZTF_sources') !== -1) : null;
+  const ZTFLightCurveCatalogNames = Array.isArray(catalogNames) ? catalogNames?.filter((name) => name.indexOf('ZTF_sources_202') !== -1) : null;
 
   const catalog = ZTFLightCurveCatalogNames
     ? ZTFLightCurveCatalogNames[0]

--- a/extensions/skyportal/static/js/components/SourceAnnotationButtonPlugins.jsx
+++ b/extensions/skyportal/static/js/components/SourceAnnotationButtonPlugins.jsx
@@ -21,7 +21,7 @@ const PositionedMenu = ({handle, menu_name, menu_items, disabled}) => {
             handle(item);
         }
     };
-  
+
     return (
         <div>
             <Button

--- a/extensions/skyportal/static/js/components/SourceAnnotationButtonPlugins.jsx
+++ b/extensions/skyportal/static/js/components/SourceAnnotationButtonPlugins.jsx
@@ -1,42 +1,121 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
 
 import CircularProgress from "@mui/material/CircularProgress";
 import Button from "./Button";
 
 import * as archiveActions from "../ducks/archive";
 
+const PositionedMenu = ({handle, menu_name, menu_items, disabled}) => {
+    const [anchorEl, setAnchorEl] = React.useState(null);
+    const open = Boolean(anchorEl);
+    const handleClickMenu = (event) => {
+        setAnchorEl(event.currentTarget);
+    };
+    const handleCloseMenu = (item) => {
+        setAnchorEl(null);
+        if (item) {
+            handle(item);
+        }
+    };
+  
+    return (
+        <div>
+            <Button
+                secondary
+                size="small"
+                id="demo-positioned-button"
+                aria-controls={open ? 'demo-positioned-menu' : undefined}
+                aria-haspopup="true"
+                aria-expanded={open ? 'true' : undefined}
+                onClick={handleClickMenu}
+                disabled={disabled}
+            >
+                {menu_name}
+            </Button>
+            <Menu
+                id={`${menu_name}_menu`}
+                aria-labelledby={`${menu_name}_menu_button`}
+                anchorEl={anchorEl}
+                open={open}
+                onClose={handleCloseMenu}
+                anchorOrigin={{
+                    vertical: 'top',
+                    horizontal: 'left',
+                }}
+                transformOrigin={{
+                    vertical: 'top',
+                    horizontal: 'left',
+                }}
+            >
+                {menu_items.map((item) => (
+                    <MenuItem onClick={
+                        (event) => {
+                            event.preventDefault();
+                            handleCloseMenu(item)
+                        }
+                    }>{item}</MenuItem>
+                ))}
+            </Menu>
+        </div>
+    );
+}
+
 const SourceAnnotationButtonPlugins = ({source}) =>
 {
     const dispatch = useDispatch();
+    const catalogNames = useSelector((state) => state.catalog_names);
+
+    useEffect(() => {
+        const fetchCatalogNames = () => {
+        dispatch(archiveActions.fetchCatalogNames());
+        };
+        if (!catalogNames) {
+            fetchCatalogNames();
+        }
+    }, [catalogNames, dispatch]);
+
+    const scope_catalogs =[];
+    if (Array.isArray(catalogNames)) {
+        // if the catalogs start with ZTF_source_features_DR, then are followed by a number, and nothing else, then they are scope catalogs
+        for (let i = 0; i < catalogNames.length; i++) {
+            if (catalogNames[i].startsWith("ZTF_source_features_DR") && !isNaN(catalogNames[i].slice(22))) {
+                scope_catalogs.push(catalogNames[i].slice(20))
+            }
+        }
+    }
 
     const [isSubmittingAnnotationScopeFeatures, setIsSubmittingAnnotationScopeFeatures] =
         useState(null);
-    const handleAnnotationScopeFeatures = async (id, ra, dec) => {
+    const handleAnnotationScopeFeatures = async (id, ra, dec, item) => {
         setIsSubmittingAnnotationScopeFeatures(id);
-        await dispatch(archiveActions.fetchScopeFeatures({id, ra, dec}));
+        const catalog = `ZTF_source_features_${item}`;
+        await dispatch(archiveActions.fetchScopeFeatures({id, ra, dec, catalog}));
         setIsSubmittingAnnotationScopeFeatures(null);
+    };
+
+    const handleMenu = (item) => {
+        if (item && scope_catalogs.includes(item)) {
+            handleAnnotationScopeFeatures(source.id, source.ra, source.dec, item);
+        }
     };
 
     return (
     <>
-        {isSubmittingAnnotationScopeFeatures === source.id ? (
+        {isSubmittingAnnotationScopeFeatures === source.id || !catalogNames ? (
         <div>
         <CircularProgress />
         </div>
     ) : (
-        <Button
-        secondary
-        onClick={() => {
-            handleAnnotationScopeFeatures(source.id, source.ra, source.dec);
-        }}
-        size="small"
-        type="submit"
-        data-testid={`scopeFeaturesRequest_${source.id}`}
-        >
-        SCoPe Features
-        </Button>
+        <PositionedMenu
+            handle={handleMenu}
+            menu_name="Scope Features"
+            menu_items={scope_catalogs}
+            disabled={scope_catalogs.length === 0}
+        />
     )}
     </>
     );


### PR DESCRIPTION
- hide catalogs that do not start with ZTF_sources_202 (it's enough to cover the 20's)
- Scope annotation import: Allow user to pick scope catalog (DR3, DR5, and soon DR16)
- Archive.py: Allow to still query available instances of Kowalski when some of them aren't accessible, instead of blocking any access.