### PR TITLE
Save ZTF alert photometry to other (nearby) sources

### DIFF
--- a/extensions/skyportal/skyportal/handlers/api/alert.py
+++ b/extensions/skyportal/skyportal/handlers/api/alert.py
@@ -1024,8 +1024,6 @@ class AlertHandler(BaseHandler):
         """
 
         data = self.get_json()
-        print(objectId)
-        print(data)
         candid = data.get("candid", None)
         group_ids = data.pop("group_ids", None)
         thumbnails_only = data.pop("thumbnailsOnly", False)

--- a/extensions/skyportal/skyportal/handlers/api/archive.py
+++ b/extensions/skyportal/skyportal/handlers/api/archive.py
@@ -323,6 +323,8 @@ class CrossMatchHandler(BaseHandler):
                 total_results = 0
                 failed_results = 0
                 for instance, instance_results in response.items():
+                    if isinstance(instance_results, dict):
+                        instance_results = [instance_results]
                     for result in instance_results:
                         if result.get("status", "error") == "success":
                             for catalog, catalog_results in result["data"].items():

--- a/extensions/skyportal/static/js/components/CopyAlertPhotometryDialog.jsx
+++ b/extensions/skyportal/static/js/components/CopyAlertPhotometryDialog.jsx
@@ -1,0 +1,127 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { useDispatch, useSelector } from "react-redux";
+import { useForm, Controller } from "react-hook-form";
+
+import Dialog from "@mui/material/Dialog";
+import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
+import Checkbox from "@mui/material/Checkbox";
+import FormControlLabel from "@mui/material/FormControlLabel";
+
+import { showNotification } from "baselayer/components/Notifications";
+import Button from "./Button";
+
+import { saveAlertAsSource } from "../ducks/alert";
+import FormValidationError from "./FormValidationError";
+
+const CopyAlertPhotometryDialog = ({
+  alert,
+  duplicate,
+  dialogOpen,
+  closeDialog,
+}) => {
+  const dispatch = useDispatch();
+
+  const groups = useSelector((state) => state.groups.userAccessible);
+
+  const {
+    handleSubmit,
+    reset,
+    control,
+    getValues,
+
+    formState: { errors },
+  } = useForm();
+
+  const currentGroupIds = duplicate.groups?.map((g) => g.id);
+
+  const savedGroups = groups?.filter((g) => currentGroupIds.includes(g.id));
+
+  const validateGroups = () => {
+    const formState = getValues();
+    return (
+      formState.groupIds?.length &&
+      formState.groupIds.filter((value) => Boolean(value)).length >= 1
+    );
+  };
+
+  const onSubmit = async (data) => {
+    const savedGroupIds = savedGroups?.map((g) => g.id);
+    const groupIds = savedGroupIds?.filter((ID, idx) => data.groupIds[idx]);
+    data.group_ids = groupIds;
+    data.copyToSource = duplicate.id;
+    const result = await dispatch(
+      saveAlertAsSource({
+        id: alert.objectId,
+        payload: data,
+      })
+    );
+    if (result.status === "success") {
+      dispatch(
+        showNotification("Source photometry updated successfully", "info")
+      );
+      reset();
+    }
+    closeDialog();
+  };
+
+  return (
+    <>
+      <Dialog open={dialogOpen} onClose={closeDialog} sx={{ "z-index": 99999 }}>
+        <DialogTitle>Copy photometry to selected groups:</DialogTitle>
+        <DialogContent>
+          <form onSubmit={handleSubmit(onSubmit)}>
+            {(errors.inviteGroupIds || errors.unsaveGroupIds) && (
+              <FormValidationError message="Select at least one group." />
+            )}
+            {!!savedGroups.length && (
+              <>
+                {savedGroups.map((savedGroup, idx) => (
+                  <FormControlLabel
+                    key={savedGroup.id}
+                    control={
+                      <Controller
+                        render={({ field: { onChange, value } }) => (
+                          <Checkbox
+                            onChange={(event) => onChange(event.target.checked)}
+                            checked={value}
+                            data-testid={`copyGroupCheckbox_${savedGroup.id}`}
+                          />
+                        )}
+                        name={`groupIds[${idx}]`}
+                        control={control}
+                        rules={{ validate: validateGroups }}
+                        defaultValue={false}
+                      />
+                    }
+                    label={savedGroup.name}
+                  />
+                ))}
+              </>
+            )}
+            <div style={{ textAlign: "center" }}>
+              <Button
+                secondary
+                type="submit"
+                name={`copyPhotometryButton_${alert.objectId}`}
+              >
+                Copy Photometry
+              </Button>
+            </div>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+};
+CopyAlertPhotometryDialog.propTypes = {
+  alert: PropTypes.shape({
+    objectId: PropTypes.string,
+  }).isRequired,
+  duplicate: PropTypes.string.isRequired,
+  dialogOpen: PropTypes.bool.isRequired,
+  closeDialog: PropTypes.func.isRequired,
+};
+
+export default CopyAlertPhotometryDialog;


### PR DESCRIPTION
- when posting an alert as a source, allow to post the data not only to the associated ZTF source but to any source within 2 arcsec. This will post photometry, but not the thumbnails as the other source could be an alert from WINTER, TURBO, PGIR,... which would replace its thumbnails. We could come up with a better behavior later.
- Thumbnail bugfix: There was a missing f in front of an f-string, rip...
- Sometimes a candid in prv_candidates doesn't exist in the alerts table. When that happens, we use the latest candid instead when posting thumbnails + notify the user.

I would suggest the reviewer to **really test this thoroughly**, as we wouldn't want existing features (see an alert and save it as a source) to not work anymore.