### PR TITLE
Temporary bugfix: prevent alert page from crashing when aux data is missing

### DIFF
--- a/extensions/skyportal/static/js/components/ZTFAlert.jsx
+++ b/extensions/skyportal/static/js/components/ZTFAlert.jsx
@@ -23,6 +23,7 @@ import Typography from "@mui/material/Typography";
 import CircularProgress from "@mui/material/CircularProgress";
 import Chip from "@mui/material/Chip";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
+import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import Tooltip from "@mui/material/Tooltip";
 
 import MUIDataTable from "mui-datatables";
@@ -461,6 +462,20 @@ const ZTFAlert = ({ route }) => {
             </div>
             <div className={classes.name}>{objectId}</div>
             <br />
+            {(alert_aux_data?.missing === true) && (
+              <>
+                <Chip
+                  title="Lost aux data (including this object's non-detections and crossmatches) is being recovered in Kowalski. In the mean time, detections were fetched using the individual alerts instead"
+                  size="small"
+                  label="Warning: missing aux data"
+                  style={{
+                    backgroundColor: "#E9D502"
+                  }}
+                  icon={<WarningAmberIcon/>}
+              />
+              <br />
+            </>
+            )}
             {savedSource || loadedSourceId === objectId ? (
               <div>
                 <div className={classes.itemPaddingBottom}>


### PR DESCRIPTION
We are currently reingesting alert data in Kowalski that has been lost. 

In production, this caused issues when users try to access the ztf alert page for a given alert, if its aux data (aggregate of the prv_candidates + cross matches) hasn't been recovered yet.

This PR does:
- if aux data is missing, append the full alert history to effectively give the user all the detections (only the non-detections are now missing).
- if the aux data is missing, show a yellow warning on the frontend, which on hover explains what process we are going through right now, and what data is still available.