### PR TITLE
Update docs GitHub actions

### DIFF
--- a/.github/workflows/build-test-doc_upload.yaml
+++ b/.github/workflows/build-test-doc_upload.yaml
@@ -11,13 +11,13 @@ jobs:
     timeout-minutes: 20
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
 
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.10'
 
     - name: Install system dependencies
       run: |


### PR DESCRIPTION
Looks like we haven't been able to build the docs after the latest release of Scypi.

This is an attempt to fix that, and in general to start using a more recent version of python here.