### PR TITLE
Kowalski filter auto-followup: don't edit original form

### DIFF
--- a/extensions/skyportal/static/js/components/FilterPlugins.jsx
+++ b/extensions/skyportal/static/js/components/FilterPlugins.jsx
@@ -386,11 +386,13 @@ const FilterPlugins = ({ group }) => {
     if (!allocationLookUp[selectedAllocationId] || !instrumentFormParams) {
       return;
     }
-    const params = {
+    const existingParams = {
       ...instrumentFormParams[
         allocationLookUp[selectedAllocationId].instrument_id
       ],
     };
+    // we make a copy of the existing params so we don't modify the original
+    const params = Object.assign({}, existingParams);
     // remove priority, start_date, and end_date if they exist in params.schema and params.uiSchema
     const deleted = [];
     if (params.formSchema) {


### PR DESCRIPTION
It looks like the current code does not make a copy as expected (probably, it does make a copy but of the lookup dict, which then still points to the original form).

This PR (untested yet) should fix that by first accessing the form in the lookup, and then making a copy of it.

The last option, which is not as "clean" but always works, is to JSON.stringify and then JSON.parse.