### PR TITLE
ZTF Alerts: Forced Photometry

### DIFF
--- a/extensions/skyportal/static/js/components/SaveAlertButton.jsx
+++ b/extensions/skyportal/static/js/components/SaveAlertButton.jsx
@@ -31,7 +31,7 @@ const SaveAlertButton = ({ alert, userGroups }) => {
   const [dialogOpen, setDialogOpen] = useState(false);
   const source = useSelector((state) => state.source);
   const groups = (useSelector((state) => state.groups.all) || []).filter(
-    (g) => !g.single_user_group
+    (g) => !g.single_user_group,
   );
 
   const currentGroupIds = source?.groups?.map((g) => g.id);
@@ -78,14 +78,14 @@ const SaveAlertButton = ({ alert, userGroups }) => {
       setIsSubmitting(false);
     } else {
       dispatch(
-        showNotification("Source photometry updated successfully", "info")
+        showNotification("Source photometry updated successfully", "info"),
       );
       if (result?.data?.used_latest_candid) {
         dispatch(
           showNotification(
             "Note that the latest alert packet was used to post thumbnails, as the provided candid didn't have any.",
-            "warning"
-          )
+            "warning",
+          ),
         );
       }
       setIsSubmitting(false);
@@ -244,14 +244,14 @@ const SaveAlertButton = ({ alert, userGroups }) => {
 SaveAlertButton.propTypes = {
   alert: PropTypes.shape({
     id: PropTypes.string,
-    candid: PropTypes.number,
+    candid: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     group_ids: PropTypes.arrayOf(PropTypes.number),
   }).isRequired,
   userGroups: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.number,
       name: PropTypes.string,
-    })
+    }),
   ).isRequired,
 };
 

--- a/extensions/skyportal/static/js/components/VegaPlotZTFAlert.jsx
+++ b/extensions/skyportal/static/js/components/VegaPlotZTFAlert.jsx
@@ -1,215 +1,238 @@
 import React from "react";
 import PropTypes from "prop-types";
 import embed from "vega-embed";
-import { isMobileOnly, withOrientationChange } from "react-device-detect";
 
-const spec = (url, jd, isPortrait) => ({
-  $schema: "https://vega.github.io/schema/vega-lite/v4.json",
-  width: isMobileOnly && isPortrait ? 250 : 500,
-  // width: "container",
-  height: isMobileOnly && isPortrait ? 150 : 250,
-  data: {
-    url,
-    format: {
-      type: "json",
-      property: "data.prv_candidates", // where in the JSON does the data live
+const spec = (url, values, jd) => {
+  const specJSON = {
+    $schema: "https://vega.github.io/schema/vega-lite/v5.2.0.json",
+    width: "container",
+    height: "container",
+    autosize: {
+      type: "fit",
+      resize: true,
     },
-  },
-  autosize: {
-    type: "fit",
-    resize: true,
-    // contains: "padding"
-  },
-  background: "transparent",
-  layer: [
-    {
-      selection: {
-        filterMags: {
-          type: "multi",
-          fields: ["fid"],
-          bind: "legend",
-        },
-        grid: {
-          type: "interval",
-          bind: "scales",
-        },
-      },
-      mark: {
-        type: "point",
-        shape: "circle",
-        filled: "true",
-        size: 30,
-      },
-      transform: [
-        {
-          calculate:
-            "join([format(datum.magpsf, '.2f'), ' ± ', format(datum.sigmapsf, '.2f'), ' (ab)'], '')",
-          as: "magAndErr",
-        },
-      ],
-      encoding: {
-        x: {
-          field: "jd",
-          type: "quantitative",
-          scale: {
-            zero: false,
+    background: "transparent",
+    layer: [
+      // Render error bars
+      {
+        selection: {
+          filterErrBars: {
+            type: "multi",
+            fields: ["fid"],
+            bind: "legend",
           },
         },
-        y: {
-          field: "magpsf",
-          type: "quantitative",
-          scale: {
-            zero: false,
-            reverse: true,
-          },
-          axis: {
-            title: "mag",
-          },
-        },
-        color: {
-          field: "fid",
-          type: "nominal",
-          scale: {
-            domain: [1, 2, 3],
-            range: ["#28a745", "#dc3545", "#f3dc11"],
-          },
-        },
-        tooltip: [
-          // { field: "candid", title: "candid" },
-          { field: "magAndErr", title: "mag", type: "nominal" },
-          { field: "fid", type: "ordinal" },
-          { field: "jd", type: "quantitative" },
-          { field: "diffmaglim", type: "quantitative", format: ".2f" },
+        transform: [
+          { filter: "datum.magpsf != null && datum.sigmapsf != null" },
+          { calculate: "datum.magpsf - datum.sigmapsf", as: "magMin" },
+          { calculate: "datum.magpsf + datum.sigmapsf", as: "magMax" },
         ],
-        opacity: {
-          condition: { selection: "filterMags", value: 1 },
-          value: 0,
+        mark: {
+          type: "rule",
+          size: 2,
+        },
+        encoding: {
+          x: {
+            field: "jd",
+            type: "quantitative",
+            scale: {
+              zero: false,
+            },
+          },
+          y: {
+            field: "magMin",
+            type: "quantitative",
+            scale: {
+              zero: false,
+              reverse: true,
+            },
+          },
+          y2: {
+            field: "magMax",
+            type: "quantitative",
+            scale: {
+              zero: false,
+              reverse: true,
+            },
+          },
+          color: {
+            field: "fid",
+            type: "nominal",
+          },
+          opacity: {
+            condition: { selection: "filterErrBars", value: 1 },
+            value: 0,
+          },
         },
       },
-    },
 
-    // Render error bars
-    {
-      selection: {
-        filterErrBars: {
-          type: "multi",
-          fields: ["fid"],
-          bind: "legend",
-        },
-      },
-      transform: [
-        { filter: "datum.magpsf != null && datum.sigmapsf != null" },
-        { calculate: "datum.magpsf - datum.sigmapsf", as: "magMin" },
-        { calculate: "datum.magpsf + datum.sigmapsf", as: "magMax" },
-      ],
-      mark: {
-        type: "rule",
-        size: 0.5,
-      },
-      encoding: {
-        x: {
-          field: "jd",
-          type: "quantitative",
-          scale: {
-            zero: false,
+      // Render Detections
+      {
+        selection: {
+          filterMags: {
+            type: "multi",
+            fields: ["fid"],
+            bind: "legend",
+          },
+          grid: {
+            name: "grid",
+            type: "interval",
+            bind: "scales",
           },
         },
-        y: {
-          field: "magMin",
-          type: "quantitative",
-          scale: {
-            zero: false,
-            reverse: true,
+        mark: {
+          type: "point",
+          shape: "circle",
+          filled: "true",
+          size: 100,
+        },
+        transform: [
+          {
+            calculate:
+              "join([format(datum.magpsf, '.2f'), ' ± ', format(datum.sigmapsf, '.2f'), ' (ab)'], '')",
+            as: "magAndErr",
           },
-        },
-        y2: {
-          field: "magMax",
-          type: "quantitative",
-          scale: {
-            zero: false,
-            reverse: true,
-          },
-        },
-        color: {
-          field: "fid",
-          type: "nominal",
-        },
-        opacity: {
-          condition: { selection: "filterErrBars", value: 1 },
-          value: 0,
-        },
-      },
-    },
-
-    // Render limiting mags
-    {
-      transform: [{ filter: "datum.magpsf == null" }],
-      selection: {
-        filterLimitingMags: {
-          type: "multi",
-          fields: ["fid"],
-          bind: "legend",
-        },
-      },
-      mark: {
-        type: "point",
-        shape: "triangle-down",
-      },
-      encoding: {
-        x: {
-          field: "jd",
-          type: "quantitative",
-          scale: {
-            zero: false,
-          },
-        },
-        y: {
-          field: "diffmaglim",
-          type: "quantitative",
-        },
-        color: {
-          field: "fid",
-          type: "nominal",
-        },
-        tooltip: [
-          { field: "fid", type: "ordinal" },
-          { field: "jd", type: "quantitative" },
-          { field: "diffmaglim", type: "quantitative", format: ".2f" },
         ],
-        opacity: {
-          condition: { selection: "filterLimitingMags", value: 0.3 },
-          value: 0,
+        encoding: {
+          x: {
+            field: "jd",
+            type: "quantitative",
+            scale: {
+              zero: false,
+            },
+          },
+          y: {
+            field: "magpsf",
+            type: "quantitative",
+            scale: {
+              zero: false,
+              reverse: true,
+            },
+            axis: {
+              title: "mag",
+            },
+          },
+          color: {
+            field: "fid",
+            type: "nominal",
+            scale: {
+              domain: [1, 2, 3],
+              range: ["#28a745", "#dc3545", "#f3dc11"],
+            },
+          },
+          tooltip: [
+            // { field: "candid", title: "candid" },
+            { field: "magAndErr", title: "mag", type: "nominal" },
+            { field: "fid", type: "ordinal" },
+            { field: "jd", type: "quantitative" },
+            { field: "diffmaglim", type: "quantitative", format: ".2f" },
+            { field: "origin", type: "ordinal" },
+          ],
+          opacity: {
+            condition: { selection: "filterMags", value: 1 },
+            value: 0,
+          },
         },
       },
-    },
 
-    // render selected candid date
-    {
-      data: { values: [{}] },
-      mark: { type: "rule", strokeDash: [4, 4], size: 2 },
-      encoding: {
-        x: {
-          datum: jd,
-          type: "quantitative",
+      // Render limiting mags
+      {
+        transform: [{ filter: "datum.magpsf == null" }],
+        selection: {
+          filterLimitingMags: {
+            type: "multi",
+            fields: ["fid"],
+            bind: "legend",
+          },
+        },
+        mark: {
+          type: "point",
+          shape: "triangle-down",
+          size: 60,
+        },
+        encoding: {
+          x: {
+            field: "jd",
+            type: "quantitative",
+            scale: {
+              zero: false,
+            },
+          },
+          y: {
+            field: "diffmaglim",
+            type: "quantitative",
+          },
+          color: {
+            field: "fid",
+            type: "nominal",
+          },
+          tooltip: [
+            { field: "fid", type: "ordinal" },
+            { field: "jd", type: "quantitative" },
+            { field: "diffmaglim", type: "quantitative", format: ".2f" },
+          ],
+          opacity: {
+            condition: { selection: "filterLimitingMags", value: 0.3 },
+            value: 0,
+          },
         },
       },
-    },
-  ],
-});
 
-const VegaPlot = withOrientationChange(({ dataUrl, jd, isPortrait }) => (
-  <div
-    ref={(node) => {
-      embed(node, spec(dataUrl, jd, isPortrait), {
-        actions: false,
-      });
-    }}
-  />
-));
+      // render selected candid date
+      {
+        data: { values: [{}] },
+        mark: { type: "rule", strokeDash: [4, 4], size: 1, opacity: 0.3 },
+        encoding: {
+          x: {
+            datum: jd,
+            type: "quantitative",
+          },
+        },
+      },
+    ],
+  };
+
+  if (url) {
+    specJSON.data = {
+      url,
+      format: {
+        type: "json",
+        property: "data.prv_candidates", // where in the JSON does the data live
+      },
+    };
+  } else {
+    specJSON.data = {
+      values,
+    };
+  }
+  return specJSON;
+};
+
+const VegaPlot = ({ dataUrl, values, jd }) => {
+  if (!dataUrl && !values) {
+    return null;
+  }
+  return (
+    <div
+      ref={(node) => {
+        embed(node, spec(dataUrl, values, jd), {
+          actions: false,
+        });
+      }}
+      style={{ width: "100%", height: "100%" }}
+    />
+  );
+};
 
 VegaPlot.propTypes = {
-  dataUrl: PropTypes.string.isRequired,
+  dataUrl: PropTypes.string,
+  values: PropTypes.arrayOf(PropTypes.shape({})),
   jd: PropTypes.number.isRequired,
+};
+
+VegaPlot.defaultProps = {
+  dataUrl: null,
+  values: null,
 };
 
 export default VegaPlot;

--- a/extensions/skyportal/static/js/ducks/alert.js
+++ b/extensions/skyportal/static/js/ducks/alert.js
@@ -18,17 +18,23 @@ export function fetchAlertData(id) {
   return API.GET(`/api/alerts/${id}`, FETCH_ALERT);
 }
 
-export const fetchAuxData = (id) =>
-  API.GET(`/api/alerts_aux/${id}`, FETCH_AUX);
+export const fetchAuxData = (id) => API.GET(`/api/alerts_aux/${id}`, FETCH_AUX);
 
 export function saveAlertAsSource({ id, payload }) {
   return API.POST(`/api/alerts/${id}`, SAVE_ALERT, payload);
 }
 
-const alertDataReducer = (state = null, action) => {
+const alertDataReducer = (state = {}, action) => {
   switch (action.type) {
     case FETCH_ALERT_OK: {
-      return action.data;
+      if (action.data.length > 0) {
+        // return action.data;
+        return {
+          ...state,
+          [action.data[0].objectId]: action.data,
+        };
+      }
+      return state;
     }
     case FETCH_ALERT_ERROR: {
       return action.message;
@@ -41,10 +47,13 @@ const alertDataReducer = (state = null, action) => {
   }
 };
 
-const auxDataReducer = (state = null, action) => {
+const auxDataReducer = (state = {}, action) => {
   switch (action.type) {
     case FETCH_AUX_OK: {
-      return action.data;
+      return {
+        ...state,
+        [action.data._id]: action.data, // eslint-disable-line no-underscore-dangle
+      };
     }
     case FETCH_AUX_ERROR: {
       return action.message;

--- a/extensions/skyportal/static/js/ducks/alerts.js
+++ b/extensions/skyportal/static/js/ducks/alerts.js
@@ -6,29 +6,37 @@ const FETCH_ALERTS_OK = "skyportal/FETCH_ALERTS_OK";
 const FETCH_ALERTS_ERROR = "skyportal/FETCH_ALERTS_ERROR";
 const FETCH_ALERTS_FAIL = "skyportal/FETCH_ALERTS_FAIL";
 
+const FETCH_ALERTS_STATS = "skyportal/FETCH_ALERTS_STATS";
+const FETCH_ALERTS_STATS_OK = "skyportal/FETCH_ALERTS_STATS_OK";
+
 // eslint-disable-next-line import/prefer-default-export
 export const fetchAlerts = ({ object_id, ra, dec, radius }) => {
-  if ((object_id) && (Object.prototype.toString.call(object_id) == Array) && ra && dec && radius) {
+  if (
+    object_id &&
+    Object.prototype.toString.call(object_id) === Array &&
+    ra &&
+    dec &&
+    radius
+  ) {
     return API.GET(
       `/api/alerts?objectId=${object_id}&ra=${ra}&dec=${dec}&radius=${radius}&radius_units=arcsec`,
-      FETCH_ALERTS
-    )
-  } if ( (object_id) && (Object.prototype.toString.call(object_id))) {
-    return API.GET(
-      `/api/alerts?objectId=${object_id}`,
-      FETCH_ALERTS
-    )
-  } if (ra && dec && radius) {
+      FETCH_ALERTS,
+    );
+  }
+  if (object_id && Object.prototype.toString.call(object_id)) {
+    return API.GET(`/api/alerts?objectId=${object_id}`, FETCH_ALERTS);
+  }
+  if (ra && dec && radius) {
     return API.GET(
       `/api/alerts?ra=${ra}&dec=${dec}&radius=${radius}&radius_units=arcsec`,
-      FETCH_ALERTS
-    )
+      FETCH_ALERTS,
+    );
   }
-  return API.GET(
-    `/api/alerts/${object_id}`,
-    FETCH_ALERTS
-  )
-}
+  return API.GET(`/api/alerts/${object_id}`, FETCH_ALERTS);
+};
+
+export const fetchAlertStats = () =>
+  API.GET("/api/alerts_stats", FETCH_ALERTS_STATS);
 
 const reducer = (state = { alerts: null, queryInProgress: false }, action) => {
   switch (action.type) {
@@ -54,6 +62,12 @@ const reducer = (state = { alerts: null, queryInProgress: false }, action) => {
       return {
         message: "uncaught error",
         queryInProgress: false,
+      };
+    }
+    case FETCH_ALERTS_STATS_OK: {
+      return {
+        ...state,
+        alertStats: action.data,
       };
     }
     default:


### PR DESCRIPTION
* fetch the fp_hists from the aux data
* make the vega plot responsive and show the forced photometry on it
* better caching of the alert data (per objectid), just like we do for the source page
* rearrange the alert page using MUI Grids
* add toggles under the plot to show/hide the upper limits and the forced photometry
* add number input to dynamically change the SNR threshold applied to the forced photometry (to show as detections or upper limits).

This should provide all the tools one needs to see the alert data in Kowalski including the forced photometry with dynamic SNR cuts.