### PR TITLE
Alerts Page: bulk save alerts & URL search params for both Alerts and Archive Pages

### DIFF
--- a/extensions/skyportal/static/js/components/Alerts.jsx
+++ b/extensions/skyportal/static/js/components/Alerts.jsx
@@ -1,4 +1,5 @@
-import React, {useState} from "react";
+import React, { useState, useEffect } from "react";
+import { useSearchParams } from "react-router-dom";
 
 import Card from "@mui/material/Card";
 import CardActions from "@mui/material/CardActions";
@@ -10,6 +11,17 @@ import MenuItem from "@mui/material/MenuItem";
 import FormHelperText from "@mui/material/FormHelperText";
 import FormControl from "@mui/material/FormControl";
 import Select from "@mui/material/Select";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import Switch from "@mui/material/Switch";
+import SaveIcon from "@mui/icons-material/Save";
+import IconButton from "@mui/material/IconButton";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogContentText from "@mui/material/DialogContentText";
+import DialogTitle from "@mui/material/DialogTitle";
+import Checkbox from "@mui/material/Checkbox";
+import Chip from "@mui/material/Chip";
 
 import Grid from "@mui/material/Grid";
 
@@ -20,21 +32,25 @@ import {
   useTheme,
   adaptV4Theme,
 } from "@mui/material/styles";
-import makeStyles from '@mui/styles/makeStyles';
+import makeStyles from "@mui/styles/makeStyles";
 import { useForm, Controller } from "react-hook-form";
 import Paper from "@mui/material/Paper";
 import MUIDataTable from "mui-datatables";
 import CircularProgress from "@mui/material/CircularProgress";
 
-import {useDispatch, useSelector} from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 
 import TableRow from "@mui/material/TableRow";
 import TableCell from "@mui/material/TableCell";
 
+import { showNotification } from "baselayer/components/Notifications";
+
 import Button from "./Button";
 import ThumbnailList from "./ThumbnailList";
-import {dec_to_dms, ra_to_hours, dms_to_dec, hours_to_ra} from "../units";
-import { showNotification } from "baselayer/components/Notifications";
+import FormValidationError from "./FormValidationError";
+
+import { dec_to_dms, ra_to_hours, dms_to_dec, hours_to_ra } from "../units";
+import { greatCircleDistance } from "../utils";
 
 import * as alertActions from "../ducks/alert";
 import * as alertsActions from "../ducks/alerts";
@@ -44,18 +60,20 @@ function isString(x) {
 }
 
 const getMuiTheme = (theme) =>
-  createTheme(adaptV4Theme({
-    palette: theme.palette,
-    overrides: {
-      MUIDataTableBodyCell: {
-        root: {
-          padding: `${theme.spacing(0.25)} 0px ${theme.spacing(
-            0.25
-          )} ${theme.spacing(1)}`,
+  createTheme(
+    adaptV4Theme({
+      palette: theme.palette,
+      overrides: {
+        MUIDataTableBodyCell: {
+          root: {
+            padding: `${theme.spacing(0.25)} 0px ${theme.spacing(
+              0.25,
+            )} ${theme.spacing(1)}`,
+          },
         },
       },
-    },
-  }));
+    }),
+  );
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -120,64 +138,124 @@ const useStyles = makeStyles((theme) => ({
     textTransform: "none",
   },
   wrapperRoot: {
-    display: 'flex',
-    alignItems: 'center',
+    display: "flex",
+    alignItems: "center",
   },
   wrapper: {
     margin: 0,
-    position: 'relative',
+    position: "relative",
   },
   buttonProgress: {
     color: theme.palette.text.secondary,
-    position: 'absolute',
-    top: '50%',
-    left: '50%',
+    position: "absolute",
+    top: "50%",
+    left: "50%",
     marginTop: -12,
     marginLeft: -12,
   },
   grid_item_table: {
     order: 2,
-    [theme.breakpoints.up('lg')]: {
+    [theme.breakpoints.up("lg")]: {
       order: 1,
     },
   },
   grid_item_search_box: {
     order: 1,
-    [theme.breakpoints.up('lg')]: {
+    [theme.breakpoints.up("lg")]: {
       order: 2,
     },
+  },
+  marginTop: {
+    marginTop: "1em",
   },
 }));
 
 const Alerts = () => {
   const dispatch = useDispatch();
   const classes = useStyles();
-
   const theme = useTheme();
-  const darkTheme = theme.palette.mode === "dark";
+
+  const [searchParams] = useSearchParams();
+
+  const { register, handleSubmit, control, getValues, reset } = useForm();
 
   const { alerts, queryInProgress } = useSelector((state) => state.alerts);
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const groups = useSelector((state) => state.groups.userAccessible);
+
+  // save alerts to SP in bulk (by objectID)
+  const [groupByObj, setGroupByObj] = useState(false);
+  const [saveDialogOpen, setSaveDialogOpen] = useState(false);
+  const [rowsToSave, setRowsToSave] = useState([]);
+  const [selectedGroups, setSelectedGroups] = useState([]);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    const objectId = searchParams.get("objectId");
+    const ra = parseFloat(searchParams.get("ra"), 10);
+    const dec = parseFloat(searchParams.get("dec"), 10);
+    let radius = parseFloat(searchParams.get("radius"), 10);
+    let radius_unit = searchParams.get("radius_unit");
+    const group_by = searchParams.get("group_by_obj");
+
+    if (!objectId && (Number.isNaN(ra) || Number.isNaN(dec))) {
+      return;
+    }
+    if (objectId) {
+      // set the values in the form
+      dispatch(
+        alertsActions.fetchAlerts({
+          object_id: objectId,
+        }),
+      );
+      reset({
+        object_id: objectId,
+      });
+    } else if (ra && dec) {
+      if (!["arcsec", "arcmin", "deg", "ra"].includes(radius_unit)) {
+        radius_unit = "arcsec";
+      }
+      if (Number.isNaN(radius)) {
+        radius = 3.0;
+      }
+      dispatch(
+        alertsActions.fetchAlerts({
+          ra,
+          dec,
+          radius,
+          radius_unit,
+        }),
+      );
+      reset({
+        ra,
+        dec,
+        radius,
+        radius_unit,
+      });
+    }
+    if ([true, "true", "t", "1", 1].includes(group_by)) {
+      setGroupByObj(true);
+    }
+  }, [dispatch, searchParams]);
 
   const makeRow = (alert) => ({
-      objectId: alert?.objectId,
-      candid: alert?.candid,
-      jd: alert?.candidate.jd,
-      ra: alert?.candidate.ra,
-      dec: alert?.candidate.dec,
-      fid: alert?.candidate.fid,
-      magpsf: alert?.candidate.magpsf,
-      sigmapsf: alert?.candidate.sigmapsf,
-      programid: alert?.candidate.programid,
-      isdiffpos: alert?.candidate.isdiffpos,
-      drb: alert?.candidate.drb,
-      acai_h: alert?.classifications?.acai_h,
-      acai_n: alert?.classifications?.acai_n,
-      acai_o: alert?.classifications?.acai_o,
-      acai_v: alert?.classifications?.acai_v,
-      acai_b: alert?.classifications?.acai_b,
-      bts: alert?.classifications?.bts,
-    });
+    objectId: alert?.objectId,
+    candid: alert?.candid,
+    jd: alert?.candidate.jd,
+    ra: alert?.candidate.ra,
+    dec: alert?.candidate.dec,
+    fid: alert?.candidate.fid,
+    magpsf: alert?.candidate.magpsf,
+    sigmapsf: alert?.candidate.sigmapsf,
+    programid: alert?.candidate.programid,
+    isdiffpos: alert?.candidate.isdiffpos,
+    drb: alert?.candidate.drb,
+    acai_h: alert?.classifications?.acai_h,
+    acai_n: alert?.classifications?.acai_n,
+    acai_o: alert?.classifications?.acai_o,
+    acai_v: alert?.classifications?.acai_v,
+    acai_b: alert?.classifications?.acai_b,
+    bts: alert?.classifications?.bts,
+  });
 
   let rows = [];
 
@@ -185,11 +263,90 @@ const Alerts = () => {
     rows = alerts.map((a) => makeRow(a));
   }
 
-  const handleRetrieveThumbnails = async (objID) => {
-    setIsSubmitting(true);
-    const payload = {"thumbnailsOnly" : true, "group_ids" : "all"};
-    await dispatch(alertActions.saveAlertAsSource({'id': objID, payload}));
-    setIsSubmitting(false);
+  // DEBUG: we only have 1 alert in the testing instance, so we duplicate the row to have 20 alerts
+  if (rows.length > 0) {
+    rows = Array(20).fill(rows[0]);
+    rows = rows.map((row, i) => {
+      const newRow = { ...row };
+      newRow.jd = row.jd + i;
+      return newRow;
+    });
+  }
+
+  if (groupByObj === true && rows.length > 0) {
+    // first find the unique objectIds
+    const uniqueObjectIds = Array.from(
+      new Set(rows.map((row) => row.objectId)),
+    );
+    // then build the new rows, which only contain the latest alert for each objectId
+    // (highest jd)
+    rows = uniqueObjectIds.map((objectId) => {
+      const alertsForObject = rows.filter((row) => row.objectId === objectId);
+      const latestAlert = alertsForObject.reduce((a, b) =>
+        a.jd > b.jd ? a : b,
+      );
+      return latestAlert;
+    });
+    // add the separation between the ra and dec used in the form
+    rows = rows.map((row) => {
+      const { ra, dec } = getValues();
+      const separation = greatCircleDistance(ra, dec, row.ra, row.dec);
+      return { ...row, separation };
+    });
+
+    // // DEBUG: clone the rows to have 3 alerts, and increase the separation by 1 arcsec
+    // rows = Array(3).fill(rows[0]);
+    // rows = rows.map((row, i) => {
+    //   const newRow = { ...row };
+    //   newRow.separation = row.separation + i;
+    //   return newRow;
+    // });
+  }
+
+  console.log(rows);
+
+  const handleSaveDialogClose = () => {
+    if (!saving) {
+      setRowsToSave([]);
+      setSaveDialogOpen(false);
+    }
+  };
+
+  const handleSaveDialogOpen = async (selectedRows) => {
+    setRowsToSave(selectedRows);
+    setSaveDialogOpen(true);
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    const objectIds = rowsToSave.data.map(
+      (rowToSave) => rows[rowToSave.dataIndex]?.objectId,
+    );
+    objectIds.forEach((objectId) => {
+      const payload = {
+        group_ids: selectedGroups,
+      };
+      dispatch(alertActions.saveAlertAsSource({ id: objectId, payload })).then(
+        (response) => {
+          if (response.status === "success") {
+            dispatch(
+              showNotification(
+                `Saved ${objectId} to groups ${selectedGroups.join(", ")}`,
+              ),
+            );
+          } else {
+            dispatch(
+              showNotification(
+                `Failed to save ${objectId} to groups ${selectedGroups.join(", ")}`,
+                "error",
+              ),
+            );
+          }
+        },
+      );
+    });
+    setSaving(false);
+    setSaveDialogOpen(false);
   };
 
   // This is just passed to MUI datatables options -- not meant to be instantiated directly.
@@ -236,27 +393,54 @@ const Alerts = () => {
               />
             </Grid>
           </Grid>
-          <Button
-            onClick={(event) => handleRetrieveThumbnails(alertData.objectId)}
-            disabled={isSubmitting}
-          >
-            Retrieve Thumbnails
-          </Button>
         </TableCell>
       </TableRow>
     );
   };
 
+  const CustomToolbar = () => (
+    <div>
+      <FormControlLabel
+        control={
+          <Switch
+            checked={groupByObj}
+            onChange={() => setGroupByObj(!groupByObj)}
+            name="groupAlerts"
+            color="primary"
+          />
+        }
+        label="Group by Object ID"
+      />
+    </div>
+  );
+
   const options = {
-    selectableRows: "none",
+    // isRowSelectable: groupByObj,
+    selectableRows: groupByObj ? "multiple" : "none",
+    customToolbarSelect: (selectedRows) => (
+      <IconButton
+        className={classes.buttonSave}
+        aria-label="save"
+        onClick={() => {
+          handleSaveDialogOpen(selectedRows);
+        }}
+        size="large"
+      >
+        <SaveIcon />
+      </IconButton>
+    ),
     expandableRows: true,
     expandableRowsOnClick: true,
     renderExpandableRow: renderPullOutRow,
     elevation: 1,
     sortOrder: {
-      name: "jd",
-      direction: "desc",
+      name:
+        groupByObj && getValues().ra && getValues().dec ? "separation" : "jd",
+      direction:
+        groupByObj && getValues().ra && getValues().dec ? "asc" : "desc",
     },
+    // additional buttons
+    customToolbar: CustomToolbar,
   };
 
   const columns = [
@@ -306,7 +490,8 @@ const Alerts = () => {
       options: {
         filter: false,
         sort: true,
-        customBodyRender: (value, tableMeta, updateValue) => ra_to_hours(value, ":"),
+        customBodyRender: (value, tableMeta, updateValue) =>
+          ra_to_hours(value, ":"),
       },
     },
     {
@@ -315,7 +500,8 @@ const Alerts = () => {
       options: {
         filter: false,
         sort: true,
-        customBodyRender: (value, tableMeta, updateValue) => dec_to_dms(value, ":"),
+        customBodyRender: (value, tableMeta, updateValue) =>
+          dec_to_dms(value, ":"),
       },
     },
     {
@@ -366,7 +552,8 @@ const Alerts = () => {
       options: {
         filter: false,
         sort: true,
-        customBodyRender: (value, tableMeta, updateValue) => value ? value.toFixed(5) : value,
+        customBodyRender: (value, tableMeta, updateValue) =>
+          value ? value.toFixed(5) : value,
       },
     },
     {
@@ -375,7 +562,8 @@ const Alerts = () => {
       options: {
         filter: false,
         sort: true,
-        customBodyRender: (value, tableMeta, updateValue) => value ? value.toFixed(5) : value,
+        customBodyRender: (value, tableMeta, updateValue) =>
+          value ? value.toFixed(5) : value,
       },
     },
     {
@@ -384,7 +572,8 @@ const Alerts = () => {
       options: {
         filter: false,
         sort: true,
-        customBodyRender: (value, tableMeta, updateValue) => value ? value.toFixed(5) : value,
+        customBodyRender: (value, tableMeta, updateValue) =>
+          value ? value.toFixed(5) : value,
       },
     },
     {
@@ -393,7 +582,8 @@ const Alerts = () => {
       options: {
         filter: false,
         sort: true,
-        customBodyRender: (value, tableMeta, updateValue) => value ? value.toFixed(5) : value,
+        customBodyRender: (value, tableMeta, updateValue) =>
+          value ? value.toFixed(5) : value,
       },
     },
     {
@@ -402,7 +592,8 @@ const Alerts = () => {
       options: {
         filter: false,
         sort: true,
-        customBodyRender: (value, tableMeta, updateValue) => value ? value.toFixed(5) : value,
+        customBodyRender: (value, tableMeta, updateValue) =>
+          value ? value.toFixed(5) : value,
       },
     },
     {
@@ -411,7 +602,8 @@ const Alerts = () => {
       options: {
         filter: false,
         sort: true,
-        customBodyRender: (value, tableMeta, updateValue) => value ? value.toFixed(5) : value,
+        customBodyRender: (value, tableMeta, updateValue) =>
+          value ? value.toFixed(5) : value,
       },
     },
     {
@@ -420,19 +612,42 @@ const Alerts = () => {
       options: {
         filter: false,
         sort: true,
-        customBodyRender: (value, tableMeta, updateValue) => value ? value.toFixed(5) : value,
+        customBodyRender: (value, tableMeta, updateValue) =>
+          value ? value.toFixed(5) : value,
       },
     },
   ];
 
-  const { register, handleSubmit, control, getValues } = useForm();
+  // if we are grouping by objectId, we add a "separation" column between declination and fid
+  if (groupByObj) {
+    const { ra, dec, object_id } = getValues();
+    if (ra && dec && !object_id) {
+      columns.splice(5, 0, {
+        name: "separation",
+        label: "Separation",
+        options: {
+          filter: false,
+          sort: true,
+          customBodyRender: (value, tableMeta, updateValue) =>
+            `${value.toFixed(2)}"`,
+        },
+      });
+    }
+  }
 
   const formSubmit = async () => {
-    const data = getValues();
-    let {object_id, ra, dec, radius, radius_unit} = data;
+    let { object_id, ra, dec, radius, radius_unit } = getValues();
+    ra = ra?.toString();
+    dec = dec?.toString();
+    radius = radius?.toString();
 
     if (!object_id?.length && !ra?.length && !dec?.length && !radius?.length) {
-      dispatch(showNotification(`You must either specify an object ID, a position`, "error"));
+      dispatch(
+        showNotification(
+          `You must either specify an object ID, a position`,
+          "error",
+        ),
+      );
       return;
     }
 
@@ -441,210 +656,370 @@ const Alerts = () => {
     }
 
     // check that if positional query is requested then all required data are supplied
-    if ((ra?.length || dec?.length || radius?.length) && !(ra?.length && dec?.length && radius?.length)) {
-      dispatch(showNotification(`Positional parameters, if specified, must be all set`, "error"));
-    }
-    else {
+    if (
+      (ra?.length || dec?.length || radius?.length) &&
+      !(ra?.length && dec?.length && radius?.length)
+    ) {
+      dispatch(
+        showNotification(
+          `Positional parameters, if specified, must be all set`,
+          "error",
+        ),
+      );
+    } else {
       if (ra?.length) {
-        if (ra?.includes(':') || ra?.includes('h') || ra?.includes('m') || ra?.includes('s')) {
-          ra = ra.replace(/h|m/g, ':').replace(/s/g, '');
+        if (
+          ra?.includes(":") ||
+          ra?.includes("h") ||
+          ra?.includes("m") ||
+          ra?.includes("s")
+        ) {
+          ra = ra.replace(/h|m/g, ":").replace(/s/g, "");
           ra = hours_to_ra(ra);
         } else {
           ra = parseFloat(ra);
         }
       }
       if (dec?.length) {
-        if (dec?.includes(':') || dec?.includes('d') || dec?.includes('m') || dec?.includes('s')) {
-          dec = dec.replace(/d|m/g, ':').replace(/s/g, '');
+        if (
+          dec?.includes(":") ||
+          dec?.includes("d") ||
+          dec?.includes("m") ||
+          dec?.includes("s")
+        ) {
+          dec = dec.replace(/d|m/g, ":").replace(/s/g, "");
           dec = dms_to_dec(dec);
         } else {
           dec = parseFloat(dec);
         }
       }
-      if (radius_unit === 'arcmin') { //convert arcmin to arcsec
+      if (radius_unit === "arcmin") {
+        //convert arcmin to arcsec
         radius = parseFloat(radius) * 60;
-      } else if (radius_unit === 'deg') { //convert deg to arcsec
+      } else if (radius_unit === "deg") {
+        //convert deg to arcsec
         radius = parseFloat(radius) * 3600;
-      } else if (radius_unit === 'rad') { //convert rad to arcsec
+      } else if (radius_unit === "rad") {
+        //convert rad to arcsec
         radius = parseFloat(radius) * 206264.80624709636;
       } else {
         radius = parseFloat(radius);
       }
 
       if (object_id?.length) {
-        dispatch(showNotification(`Object ID specified, ignored positional parameters`, 'warning'));
+        dispatch(
+          showNotification(
+            `Object ID specified, ignored positional parameters`,
+            "warning",
+          ),
+        );
         ra = null;
         dec = null;
         radius = null;
-      } else if (Number.isNaN(parseFloat(ra)) || Number.isNaN(parseFloat(dec)) || Number.isNaN(parseFloat(radius))) {
-        dispatch(showNotification(`Invalid positional parameters`, 'error'));
+      } else if (
+        Number.isNaN(parseFloat(ra)) ||
+        Number.isNaN(parseFloat(dec)) ||
+        Number.isNaN(parseFloat(radius))
+      ) {
+        dispatch(showNotification(`Invalid positional parameters`, "error"));
         return;
       }
-      if (object_id?.indexOf(',') > -1) {
-        const object_id_split = object_id.split(',');
-        dispatch(alertsActions.fetchAlerts({ object_id : object_id_split, ra, dec, radius }));
+      if (object_id?.indexOf(",") > -1) {
+        const object_id_split = object_id.split(",");
+        dispatch(
+          alertsActions.fetchAlerts({
+            object_id: object_id_split,
+            ra,
+            dec,
+            radius,
+          }),
+        );
       } else {
         dispatch(alertsActions.fetchAlerts({ object_id, ra, dec, radius }));
       }
     }
   };
 
-  return <>
-    <div>
-      <Grid
-        container
-        direction="row"
-        justifyContent="flex-start"
-        alignItems="flex-start"
-        spacing={1}
-      >
-        <Grid item xs={12} lg={10} className={classes.grid_item_table}>
-          <Paper elevation={1}>
-            <div className={classes.maindiv}>
-              <div className={classes.accordionDetails}>
-                <StyledEngineProvider injectFirst>
-                  <ThemeProvider theme={getMuiTheme(theme)}>
-                    {queryInProgress ? <CircularProgress /> : (
-                      <MUIDataTable
-                        title="Alerts"
-                        data={rows}
-                        columns={columns}
-                        options={options}
+  return (
+    <>
+      <div>
+        <Grid
+          container
+          direction="row"
+          justifyContent="flex-start"
+          alignItems="flex-start"
+          spacing={1}
+        >
+          <Grid item xs={12} lg={10} className={classes.grid_item_table}>
+            <Paper elevation={1}>
+              <div className={classes.maindiv}>
+                <div className={classes.accordionDetails}>
+                  <StyledEngineProvider injectFirst>
+                    <ThemeProvider theme={getMuiTheme(theme)}>
+                      {queryInProgress ? (
+                        <CircularProgress />
+                      ) : (
+                        <MUIDataTable
+                          title={
+                            groupByObj
+                              ? "Alerts (grouped by Object ID)"
+                              : "Alerts"
+                          }
+                          data={rows}
+                          columns={columns}
+                          options={options}
+                        />
+                      )}
+                    </ThemeProvider>
+                  </StyledEngineProvider>
+                </div>
+              </div>
+            </Paper>
+          </Grid>
+          <Grid item xs={12} lg={2} className={classes.grid_item_search_box}>
+            <Card className={classes.root}>
+              <form onSubmit={handleSubmit(formSubmit)}>
+                <CardContent className={classes.cardContent}>
+                  <FormControl required className={classes.selectEmpty}>
+                    <InputLabel name="alert-stream-select-required-label">
+                      Instrument
+                    </InputLabel>
+                    <Controller
+                      labelId="alert-stream-select-required-label"
+                      name="instrument"
+                      control={control}
+                      rules={{ required: true }}
+                      render={({ field: { onChange, value } }) => (
+                        <Select
+                          value={value}
+                          onChange={onChange}
+                          defaultValue="ztf"
+                        >
+                          <MenuItem value="ztf">ZTF</MenuItem>
+                        </Select>
+                      )}
+                    />
+                    <FormHelperText>Required</FormHelperText>
+                  </FormControl>
+                  <Controller
+                    render={({ field: { onChange, value } }) => (
+                      <TextField
+                        autoFocus
+                        margin="dense"
+                        name="object_id"
+                        label="objectId"
+                        type="text"
+                        fullWidth
+                        inputRef={register("object_id", {
+                          minLength: 3,
+                          required: false,
+                        })}
+                        value={value}
+                        onChange={onChange}
                       />
                     )}
-                  </ThemeProvider>
-                </StyledEngineProvider>
-              </div>
-            </div>
-          </Paper>
-        </Grid>
-        <Grid item xs={12} lg={2} className={classes.grid_item_search_box}>
-          <Card className={classes.root}>
-            <form onSubmit={handleSubmit(formSubmit)}>
-              <CardContent className={classes.cardContent}>
-                <FormControl required className={classes.selectEmpty}>
-                  <InputLabel name="alert-stream-select-required-label">
-                    Instrument
-                  </InputLabel>
-                  <Controller
-                    labelId="alert-stream-select-required-label"
-                    name="instrument"
+                    name="object_id"
                     control={control}
-                    rules={{ required: true }}
+                  />
+                  <Controller
                     render={({ field: { onChange, value } }) => (
-                      <Select value={value} onChange={onChange} defaultValue="ztf">
-                        <MenuItem value="ztf">ZTF</MenuItem>
-                      </Select>
+                      <TextField
+                        margin="dense"
+                        name="ra"
+                        label="RA [deg, HH:MM:SS, HHhMMmSSs]"
+                        fullWidth
+                        inputRef={register("ra", { required: false })}
+                        value={value}
+                        onChange={onChange}
+                      />
                     )}
+                    name="ra"
+                    control={control}
                   />
-                  <FormHelperText>Required</FormHelperText>
-                </FormControl>
-               <Controller
-                render={({ field: { onChange, value } }) => (
-                 <TextField
-                  autoFocus
-                  margin="dense"
-                  name="object_id"
-                  label="objectId"
-                  type="text"
-                  fullWidth
-                  inputRef={register("object_id", { minLength: 3, required: false })}
-                  value={value}
-                  onChange={onChange}
-                 />
-                )}
-                name="object_id"
-                control={control}
-              />
-              <Controller
-               render={({ field: { onChange, value } }) => (
-                <TextField
-                  margin="dense"
-                  name="ra"
-                  label="RA [deg, HH:MM:SS, HHhMMmSSs]"
-                  fullWidth
-                  inputRef={register('ra', { required: false })}
-                  value={value}
-                  onChange={onChange}
-                />
-                )}
-                name="ra"
-                control={control}
-              />
-              <Controller
-               render={({ field: { onChange, value } }) => (
-                <TextField
-                  margin="dense"
-                  name="dec"
-                  label="Dec [deg, DD:MM:SS, DDdMMmSSs]"
-                  fullWidth
-                  inputRef={register('dec', { required: false })}
-                  value={value}
-                  onChange={onChange}
-                />
-                )}
-                name="dec"
-                control={control}
-              />
-              <div style={{display: 'flex', flexDirection: 'row', justifyContent: 'space-between', gap: '0.5rem'}}>
-                <Controller
-                render={({ field: { onChange, value } }) => (
-                  <TextField
-                    margin="dense"
-                    name="radius"
-                    label="Radius"
-                    fullWidth
-                    inputRef={register('radius', { required: false })}
-                    value={value}
-                    onChange={onChange}
+                  <Controller
+                    render={({ field: { onChange, value } }) => (
+                      <TextField
+                        margin="dense"
+                        name="dec"
+                        label="Dec [deg, DD:MM:SS, DDdMMmSSs]"
+                        fullWidth
+                        inputRef={register("dec", { required: false })}
+                        value={value}
+                        onChange={onChange}
+                      />
+                    )}
+                    name="dec"
+                    control={control}
                   />
-                  )}
-                  name="radius"
-                  control={control}
-                />
-                <Controller
-                  labelId="radius-unit-select-required-label"
-                  name="radius_unit"
-                  control={control}
-                  rules={{ required: true }}
-                  render={({ field: { onChange, value } }) => (
-                    <Select value={value} onChange={onChange} defaultValue="arcsec"
-                      inputRef={register('radius_unit', { required: true })}
-                      margin="dense"
-                      fullWidth
-                      style={{height: "3.5rem", marginTop: "8px", marginBottom: "4px"}}
-                    >
-                      <MenuItem value="arcsec">arcsec</MenuItem>
-                      <MenuItem value="arcmin">arcmin</MenuItem>
-                      <MenuItem value="deg">deg</MenuItem>
-                      <MenuItem value="rad">rad</MenuItem>
-                    </Select>
-                  )}
-                />
-              </div>
-              </CardContent>
-              <CardActions className={classes.cardActions}>
-                <div className={classes.wrapperRoot}>
-                  <div className={classes.wrapper}>
-                    <Button
-                      type="submit"
-                      variant="contained"
-                      color="primary"
-                      onClick={() => formSubmit()}
-                      disabled={queryInProgress}
-                    >
-                      Search
-                    </Button>
-                    {queryInProgress && <CircularProgress size={24} color="secondary" className={classes.buttonProgress} />}
+                  <div
+                    style={{
+                      display: "flex",
+                      flexDirection: "row",
+                      justifyContent: "space-between",
+                      gap: "0.5rem",
+                    }}
+                  >
+                    <Controller
+                      render={({ field: { onChange, value } }) => (
+                        <TextField
+                          margin="dense"
+                          name="radius"
+                          label="Radius"
+                          fullWidth
+                          inputRef={register("radius", { required: false })}
+                          value={value}
+                          onChange={onChange}
+                        />
+                      )}
+                      name="radius"
+                      control={control}
+                    />
+                    <Controller
+                      labelId="radius-unit-select-required-label"
+                      name="radius_unit"
+                      control={control}
+                      rules={{ required: true }}
+                      render={({ field: { onChange, value } }) => (
+                        <Select
+                          value={value}
+                          onChange={onChange}
+                          defaultValue="arcsec"
+                          inputRef={register("radius_unit", { required: true })}
+                          margin="dense"
+                          fullWidth
+                          style={{
+                            height: "3.5rem",
+                            marginTop: "8px",
+                            marginBottom: "4px",
+                          }}
+                        >
+                          <MenuItem value="arcsec">arcsec</MenuItem>
+                          <MenuItem value="arcmin">arcmin</MenuItem>
+                          <MenuItem value="deg">deg</MenuItem>
+                          <MenuItem value="rad">rad</MenuItem>
+                        </Select>
+                      )}
+                    />
                   </div>
-                </div>
-              </CardActions>
-            </form>
-          </Card>
+                </CardContent>
+                <CardActions className={classes.cardActions}>
+                  <div className={classes.wrapperRoot}>
+                    <div className={classes.wrapper}>
+                      <Button
+                        type="submit"
+                        variant="contained"
+                        color="primary"
+                        onClick={() => formSubmit()}
+                        disabled={queryInProgress}
+                      >
+                        Search
+                      </Button>
+                      {queryInProgress && (
+                        <CircularProgress
+                          size={24}
+                          color="secondary"
+                          className={classes.buttonProgress}
+                        />
+                      )}
+                    </div>
+                  </div>
+                </CardActions>
+              </form>
+            </Card>
+          </Grid>
         </Grid>
-      </Grid>
-    </div>
-  </>;
+        <Dialog
+          open={saveDialogOpen}
+          onClose={handleSaveDialogClose}
+          aria-labelledby="responsive-dialog-title"
+          maxWidth="md"
+        >
+          <DialogTitle id="responsive-dialog-title">
+            Save Alert(s) as Source(s)
+          </DialogTitle>
+          <DialogContent>
+            <DialogContentText>
+              Save the following alert(s) as source(s) to the selected group(s):
+            </DialogContentText>
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "row",
+                flexWrap: "wrap",
+                width: "100%",
+              }}
+            >
+              {(rowsToSave.data || []).map((row) => (
+                <Chip
+                  key={row.dataIndex}
+                  label={`${rows[row.dataIndex]?.objectId}`}
+                />
+              ))}
+            </div>
+            <DialogContentText className={classes.marginTop}>
+              Select groups to save new source to:
+            </DialogContentText>
+            {selectedGroups?.length === 0 && (
+              <FormValidationError message="Select at least one group." />
+            )}
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "row",
+                flexWrap: "wrap",
+                width: "100%",
+              }}
+            >
+              {groups.map((group) => (
+                <div key={group.id}>
+                  <Checkbox
+                    color="primary"
+                    /* eslint-disable-next-line react/jsx-props-no-spreading */
+                    checked={selectedGroups.includes(group.id)}
+                    onChange={(e) => {
+                      if (e.target.checked) {
+                        setSelectedGroups((prev) => [...prev, group.id]);
+                      } else {
+                        setSelectedGroups(
+                          selectedGroups.filter((g) => g !== group.id),
+                        );
+                      }
+                    }}
+                  />
+                  {group.nickname || group.name}
+                </div>
+              ))}
+            </div>
+          </DialogContent>
+          <DialogActions>
+            <Button
+              variant="contained"
+              color="primary"
+              className={classes.search_button}
+              type="submit"
+              data-testid="save-dialog-submit"
+              onClick={() => handleSave()}
+              disabled={
+                selectedGroups?.length === 0 ||
+                rowsToSave?.length === 0 ||
+                saving
+              }
+            >
+              Save
+            </Button>
+            <Button
+              autoFocus
+              onClick={handleSaveDialogClose}
+              color="primary"
+              disabled={saving}
+            >
+              Dismiss
+            </Button>
+          </DialogActions>
+        </Dialog>
+      </div>
+    </>
+  );
 };
 
 export default Alerts;

--- a/extensions/skyportal/static/js/components/AlertsSearchButton.jsx
+++ b/extensions/skyportal/static/js/components/AlertsSearchButton.jsx
@@ -1,20 +1,12 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { useDispatch } from "react-redux";
 import { Link } from "react-router-dom";
 
-import * as alertsActions from "../ducks/alerts";
 
 const AlertsSearchButton = ({ ra, dec, radius = 3 }) => {
-  const dispatch = useDispatch();
-  const handleClick = () => {
-    dispatch(alertsActions.fetchAlerts({ object_id: null, ra, dec, radius }));
-  };
-
   return (
     <Link
-      to="/alerts"
-      onClick={handleClick}
+      to={`/alerts?ra=${ra}&dec=${dec}&radius=${radius}&group_by_obj=true`}
       target="_blank"
       style={{ textDecoration: "none", color: "black" }}
     >

--- a/extensions/skyportal/static/js/components/Archive.jsx
+++ b/extensions/skyportal/static/js/components/Archive.jsx
@@ -1,6 +1,7 @@
-import React, {Suspense, useEffect, useState} from "react";
+import React, { Suspense, useEffect, useState } from "react";
 import { useForm, Controller } from "react-hook-form";
-import {useDispatch, useSelector} from "react-redux";
+import { useSearchParams } from "react-router-dom";
+import { useDispatch, useSelector } from "react-redux";
 import MUIDataTable from "mui-datatables";
 
 import {
@@ -10,7 +11,7 @@ import {
   useTheme,
   adaptV4Theme,
 } from "@mui/material/styles";
-import makeStyles from '@mui/styles/makeStyles';
+import makeStyles from "@mui/styles/makeStyles";
 import Button from "@mui/material/Button";
 import Card from "@mui/material/Card";
 import CardActions from "@mui/material/CardActions";
@@ -24,7 +25,7 @@ import DialogContent from "@mui/material/DialogContent";
 import DialogContentText from "@mui/material/DialogContentText";
 import DialogTitle from "@mui/material/DialogTitle";
 import FormControl from "@mui/material/FormControl";
-import FormControlLabel from '@mui/material/FormControlLabel';
+import FormControlLabel from "@mui/material/FormControlLabel";
 import FormHelperText from "@mui/material/FormHelperText";
 import Grid from "@mui/material/Grid";
 import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
@@ -34,8 +35,8 @@ import MenuItem from "@mui/material/MenuItem";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import Paper from "@mui/material/Paper";
 import Popover from "@mui/material/Popover";
-import Radio from '@mui/material/Radio';
-import RadioGroup from '@mui/material/RadioGroup';
+import Radio from "@mui/material/Radio";
+import RadioGroup from "@mui/material/RadioGroup";
 import SaveIcon from "@mui/icons-material/Save";
 import Select from "@mui/material/Select";
 import TableCell from "@mui/material/TableCell";
@@ -46,7 +47,7 @@ import useMediaQuery from "@mui/material/useMediaQuery";
 
 import { showNotification } from "baselayer/components/Notifications";
 import FormValidationError from "./FormValidationError";
-import {dec_to_dms, ra_to_hours, dms_to_dec, hours_to_ra} from "../units";
+import { dec_to_dms, ra_to_hours, dms_to_dec, hours_to_ra } from "../units";
 import * as archiveActions from "../ducks/archive";
 import { checkSource } from "../ducks/source";
 
@@ -55,29 +56,33 @@ function isString(x) {
 }
 
 const getMuiTheme = (theme) =>
-  createTheme(adaptV4Theme({
-    palette: theme.palette,
-    overrides: {
-      MUIDataTableBodyCell: {
-        root: {
-          padding: `${theme.spacing(0.25)} 0px ${theme.spacing(
-            0.25
-          )} ${theme.spacing(1)}`,
+  createTheme(
+    adaptV4Theme({
+      palette: theme.palette,
+      overrides: {
+        MUIDataTableBodyCell: {
+          root: {
+            padding: `${theme.spacing(0.25)} 0px ${theme.spacing(
+              0.25,
+            )} ${theme.spacing(1)}`,
+          },
         },
       },
-    },
-  }));
+    }),
+  );
 
 const getMuiPopoverTheme = () =>
-  createTheme(adaptV4Theme({
-    overrides: {
-      MuiPopover: {
-        paper: {
-          maxWidth: "30rem",
+  createTheme(
+    adaptV4Theme({
+      overrides: {
+        MuiPopover: {
+          paper: {
+            maxWidth: "30rem",
+          },
         },
       },
-    },
-  }));
+    }),
+  );
 
 const VegaPlotZTFArchive = React.lazy(() => import("./VegaPlotZTFArchive"));
 
@@ -144,30 +149,30 @@ const useStyles = makeStyles((theme) => ({
     textTransform: "none",
   },
   wrapperRoot: {
-    display: 'flex',
-    alignItems: 'center',
+    display: "flex",
+    alignItems: "center",
   },
   wrapper: {
     margin: 0,
-    position: 'relative',
+    position: "relative",
   },
   buttonProgress: {
     color: theme.palette.text.secondary,
-    position: 'absolute',
-    top: '50%',
-    left: '50%',
+    position: "absolute",
+    top: "50%",
+    left: "50%",
     marginTop: -12,
     marginLeft: -12,
   },
   grid_item_table: {
     order: 2,
-    [theme.breakpoints.up('lg')]: {
+    [theme.breakpoints.up("lg")]: {
       order: 1,
     },
   },
   grid_item_search_box: {
     order: 1,
-    [theme.breakpoints.up('lg')]: {
+    [theme.breakpoints.up("lg")]: {
       order: 2,
     },
   },
@@ -183,7 +188,7 @@ const useStyles = makeStyles((theme) => ({
   },
   marginTop: {
     marginTop: theme.spacing(2),
-  }
+  },
 }));
 
 const ZTFLightCurveColors = {
@@ -195,44 +200,46 @@ const ZTFLightCurveColors = {
 const Archive = () => {
   const dispatch = useDispatch();
   const classes = useStyles();
-
-  const [catalogNamesLoadError, setCatalogNamesLoadError] = React.useState("");
-
   const theme = useTheme();
-
-  // save data to SP
-  const [saveDialogOpen, setSaveDialogOpen] = useState(false);
-
-  const { formState: { errors }, handleSubmit, control, register, getValues} = useForm();
-  const { handleSubmit: handleSubmit2, control: control2, register: register2, getValues: getValues2} = useForm();
-
   const fullScreen = !useMediaQuery(theme.breakpoints.up("md"));
 
-  const [rowsToSave, setRowsToSave] = useState([]);
+  const [searchParams] = useSearchParams();
 
-  const nearestSources = useSelector(
-    (state) => state.nearest_sources?.sources
-  );
-
-  const userGroups = useSelector(
-    (state) => state.groups.userAccessible
-  );
-
+  const nearestSources = useSelector((state) => state.nearest_sources?.sources);
+  const userGroups = useSelector((state) => state.groups.userAccessible);
   const userGroupIds = useSelector((state) =>
-    state.groups.userAccessible?.map((a) => a.id)
+    state.groups.userAccessible?.map((a) => a.id),
+  );
+  const catalogNames = useSelector((state) => state.catalog_names);
+  const { lightCurves: ztf_light_curves, queryInProgress } = useSelector(
+    (state) => state.ztf_light_curves,
   );
 
+  const {
+    formState: { errors },
+    control,
+    register,
+    getValues,
+    reset,
+  } = useForm();
+  const {
+    handleSubmit: handleSubmit2,
+    control: control2,
+    getValues: getValues2,
+  } = useForm();
+  const { handleSubmit: handleSubmitForm } = useForm();
+
+  const [catalogNamesLoadError, setCatalogNamesLoadError] = React.useState("");
+  const [catalogOptions, setCatalogOptions] = React.useState([]);
+  const [selectedCatalog, setSelectedCatalog] = useState();
+
+  const [rowsToSave, setRowsToSave] = useState([]);
+  const [saveDialogOpen, setSaveDialogOpen] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [saveNewSource, setSaveNewSource] = useState(false);
   const [searchHeaderAnchor, setSearchHeaderAnchor] = useState(null);
   const searchHelpOpen = Boolean(searchHeaderAnchor);
   const searchHelpId = searchHelpOpen ? "simple-popover" : undefined;
-  const handleClickSearchHelp = (event) => {
-    setSearchHeaderAnchor(event.currentTarget);
-  };
-  const handleCloseSearchHelp = () => {
-    setSearchHeaderAnchor(null);
-  };
-
-  const catalogNames = useSelector((state) => state.catalog_names);
 
   useEffect(() => {
     const fetchCatalogNames = async () => {
@@ -244,12 +251,214 @@ const Archive = () => {
         }
       }
     };
-    if (!catalogNames) fetchCatalogNames();
+    if (!catalogNames) {
+      fetchCatalogNames();
+    } else {
+      const ztf_lc_catalogs = Array.isArray(catalogNames)
+        ? catalogNames?.filter((name) => name.indexOf("ZTF_sources_202") !== -1)
+        : [];
+      setCatalogOptions(ztf_lc_catalogs);
+    }
   }, [catalogNames, dispatch, catalogNamesLoadError]);
 
-  const ZTFLightCurveCatalogNames = Array.isArray(catalogNames) ? catalogNames?.filter((name) => name.indexOf('ZTF_sources_202') !== -1) : null;
+  useEffect(() => {
+    const ra = parseFloat(searchParams.get("ra"), 10);
+    const dec = parseFloat(searchParams.get("dec"), 10);
+    let radius = parseFloat(searchParams.get("radius"), 10);
+    let radius_unit = searchParams.get("radius_unit");
+    let catalog = searchParams.get("catalog");
 
-  const { lightCurves: ztf_light_curves, queryInProgress } = useSelector((state) => state.ztf_light_curves);
+    const ztf_lc_catalogs = Array.isArray(catalogNames)
+      ? catalogNames?.filter((name) => name.indexOf("ZTF_sources_202") !== -1)
+      : [];
+
+    if (!selectedCatalog && ztf_lc_catalogs?.length > 0) {
+      setSelectedCatalog(ztf_lc_catalogs[0]);
+    }
+
+    if (ztf_lc_catalogs?.length < 1 || Number.isNaN(ra) || Number.isNaN(dec)) {
+      return;
+    }
+    if (Number.isNaN(radius)) {
+      radius = 3;
+    }
+    if (!["arcsec", "arcmin", "deg", "ra"].includes(radius_unit)) {
+      radius_unit = "arcsec";
+    }
+    if (selectedCatalog && !catalog) {
+      catalog = selectedCatalog;
+    } else if (!catalog || !ztf_lc_catalogs.includes(catalog)) {
+      catalog = ztf_lc_catalogs[0];
+    } else if (catalog && ztf_lc_catalogs.includes(catalog)) {
+      setSelectedCatalog(catalog);
+    }
+    reset({ ra, dec, radius, radius_unit, catalog: catalog });
+
+    if (ra && dec && radius && radius_unit && catalog) {
+      switch (radius_unit) {
+        case "arcmin":
+          radius = radius * 60; //convert arcmin to arcsec
+          break;
+        case "deg":
+          radius = radius * 3600; //convert deg to arcsec
+          break;
+        case "rad":
+          radius = radius * 206264.80624709636; //convert rad to arcsec
+          break;
+        default:
+          break;
+      }
+      dispatch(
+        archiveActions.fetchZTFLightCurves({ catalog, ra, dec, radius }),
+      );
+    }
+  }, [catalogNames, searchParams]);
+
+  const handleClickSearchHelp = (event) => {
+    setSearchHeaderAnchor(event.currentTarget);
+  };
+
+  const handleCloseSearchHelp = () => {
+    setSearchHeaderAnchor(null);
+  };
+
+  const submitSearch = async () => {
+    const data = getValues();
+    let { catalog, ra, dec, radius, radius_unit } = data;
+    ra = ra?.toString();
+    dec = dec?.toString();
+    radius = radius?.toString();
+    setSelectedCatalog(catalog);
+    // check that if positional query is requested then all required data are supplied
+    if (ra.length && dec.length && radius.length) {
+      if (ra?.length) {
+        if (
+          ra?.includes(":") ||
+          ra?.includes("h") ||
+          ra?.includes("m") ||
+          ra?.includes("s")
+        ) {
+          ra = ra.replace(/h|m/g, ":").replace(/s/g, "");
+          ra = hours_to_ra(ra);
+        } else {
+          ra = parseFloat(ra);
+        }
+      }
+      if (dec?.length) {
+        if (
+          dec?.includes(":") ||
+          dec?.includes("d") ||
+          dec?.includes("m") ||
+          dec?.includes("s")
+        ) {
+          dec = dec.replace(/d|m/g, ":").replace(/s/g, "");
+          dec = dms_to_dec(dec);
+        } else {
+          dec = parseFloat(dec);
+        }
+      }
+      if (
+        Number.isNaN(parseFloat(ra)) ||
+        Number.isNaN(parseFloat(dec)) ||
+        Number.isNaN(parseFloat(radius))
+      ) {
+        dispatch(showNotification(`Invalid positional parameters`, "error"));
+        return;
+      }
+      if (radius_unit === "arcmin") {
+        //convert arcmin to arcsec
+        radius = parseFloat(radius) * 60;
+      } else if (radius_unit === "deg") {
+        //convert deg to arcsec
+        radius = parseFloat(radius) * 3600;
+      } else if (radius_unit === "rad") {
+        //convert rad to arcsec
+        radius = parseFloat(radius) * 206264.80624709636;
+      } else {
+        radius = parseFloat(radius);
+      }
+      dispatch(
+        archiveActions.fetchZTFLightCurves({ catalog, ra, dec, radius }),
+      );
+      // also fetch nearest saved sources within 5 arcsec from requested position
+      dispatch(archiveActions.fetchNearestSources({ ra, dec }));
+    } else {
+      dispatch(
+        showNotification(`Positional parameters must be all set`, "warning"),
+      );
+    }
+  };
+
+  const handleSaveDialogClose = () => {
+    setRowsToSave([]);
+    setSaveDialogOpen(false);
+  };
+
+  const handleSaveDialogOpen = async (selectedRows) => {
+    setRowsToSave(selectedRows);
+    const row = rows[selectedRows.data[0].dataIndex];
+    dispatch(axrchiveActions.fetchNearestSources({ ra: row.ra, dec: row.dec }));
+    setSaveDialogOpen(true);
+  };
+
+  const validateGroups = () => {
+    const formState = getValues();
+    if (saveNewSource) {
+      return formState.group_ids.filter((value) => Boolean(value)).length >= 1;
+    }
+    return true;
+  };
+
+  const onSubmitSave = async () => {
+    setIsSubmitting(true);
+
+    const data2 = getValues2();
+
+    let objID;
+    if (data2.name && data2.name !== "") {
+      objID = data2.name;
+    } else {
+      objID = data2.obj_id === "Create new source" ? null : data2.obj_id;
+    }
+
+    if (saveNewSource) {
+      let data = null;
+      const row = rows[rowsToSave.data[0].dataIndex];
+      data = await dispatch(
+        checkSource(objID, { ra: row.ra, dec: row.dec, nameOnly: true }),
+      );
+      if (data.data !== "A source of that name does not exist.") {
+        dispatch(showNotification(data.data, "error"));
+        setIsSubmitting(false);
+        return;
+      }
+    }
+
+    // IDs of selected groups:
+    const groupIDs = userGroupIds.filter(
+      (groupId, index) => data2.group_ids[index],
+    );
+    // IDs of selected light curves
+    const lightCurveIDs = rowsToSave.data.map(
+      // eslint-disable-next-line no-underscore-dangle
+      (rowToSave) => rows[rowToSave.dataIndex]._id,
+    );
+
+    const payload = {
+      obj_id: objID,
+      catalog: selectedCatalog,
+      light_curve_ids: lightCurveIDs,
+    };
+
+    payload.group_ids = groupIDs;
+
+    const result = await dispatch(archiveActions.saveLightCurves(payload));
+    if (result.status === "success") {
+      dispatch(showNotification("Successfully saved data"));
+      handleSaveDialogClose();
+    }
+    setIsSubmitting(false);
+  };
 
   const makeRow = (light_curve) => ({
     // eslint-disable-next-line no-underscore-dangle
@@ -263,10 +472,14 @@ const Archive = () => {
     refmag: light_curve?.refmag,
     refmagerr: light_curve?.refmagerr,
     iqr: light_curve?.iqr,
-    });
+  });
   let rows = [];
 
-  if (ztf_light_curves !== null && !isString(ztf_light_curves) && Array.isArray(ztf_light_curves)) {
+  if (
+    ztf_light_curves !== null &&
+    !isString(ztf_light_curves) &&
+    Array.isArray(ztf_light_curves)
+  ) {
     rows = ztf_light_curves.map((a) => makeRow(a));
   }
 
@@ -277,12 +490,12 @@ const Archive = () => {
     const ZTFLightCurveId = ztf_light_curves[rowMeta.dataIndex]._id;
     const ZTFLightCurveFilterId = ztf_light_curves[rowMeta.dataIndex].filter;
     const ZTFLightCurveData = ztf_light_curves[rowMeta.dataIndex].data.map(
-      obj => ({ ...obj, filter: ZTFLightCurveFilterId })
+      (obj) => ({ ...obj, filter: ZTFLightCurveFilterId }),
     );
     const colorScale = {
       domain: [ZTFLightCurveFilterId],
       range: [ZTFLightCurveColors[ZTFLightCurveFilterId]],
-    }
+    };
 
     return (
       <TableRow data-testid={`ZTFLightCurveRow_${ZTFLightCurveId}`}>
@@ -315,17 +528,18 @@ const Archive = () => {
 
   const options = {
     selectableRows: "multiple",
-    customToolbarSelect: selectedRows => (
+    customToolbarSelect: (selectedRows) => (
       <IconButton
         className={classes.buttonSave}
         aria-label="save"
         onClick={() => {
           handleSaveDialogOpen(selectedRows);
         }}
-        size="large">
+        size="large"
+      >
         <SaveIcon />
       </IconButton>
-     ),
+    ),
     expandableRows: true,
     expandableRowsOnClick: true,
     renderExpandableRow: renderPullOutRow,
@@ -352,7 +566,8 @@ const Archive = () => {
       options: {
         filter: false,
         sort: true,
-        customBodyRender: (value, tableMeta, updateValue) => ra_to_hours(value, ":"),
+        customBodyRender: (value, tableMeta, updateValue) =>
+          ra_to_hours(value, ":"),
       },
     },
     {
@@ -361,7 +576,8 @@ const Archive = () => {
       options: {
         filter: false,
         sort: true,
-        customBodyRender: (value, tableMeta, updateValue) => dec_to_dms(value, ":"),
+        customBodyRender: (value, tableMeta, updateValue) =>
+          dec_to_dms(value, ":"),
       },
     },
     {
@@ -412,7 +628,8 @@ const Archive = () => {
       options: {
         filter: false,
         sort: true,
-        customBodyRender: (value, tableMeta, updateValue) => value ? value.toFixed(5) : value,
+        customBodyRender: (value, tableMeta, updateValue) =>
+          value ? value.toFixed(5) : value,
       },
     },
     {
@@ -421,140 +638,13 @@ const Archive = () => {
       options: {
         filter: false,
         sort: true,
-        customBodyRender: (value, tableMeta, updateValue) => value ? value.toFixed(5) : value,
+        customBodyRender: (value, tableMeta, updateValue) =>
+          value ? value.toFixed(5) : value,
       },
     },
   ];
 
-  const handleSaveDialogClose = () => {
-    setRowsToSave([]);
-    setSaveDialogOpen(false);
-  };
-
-  const handleSaveDialogOpen = async (selectedRows) => {
-    setRowsToSave(selectedRows);
-    const row = rows[selectedRows.data[0].dataIndex];
-    dispatch(archiveActions.fetchNearestSources({'ra': row.ra, 'dec': row.dec}));
-    setSaveDialogOpen(true);
-  };
-
-  const { register: registerForm, handleSubmit: handleSubmitForm, control: controlForm } = useForm();
-
-  const [selectedCatalog, setSelectedCatalog] = useState(
-    ZTFLightCurveCatalogNames?.length ? ZTFLightCurveCatalogNames[0] : null
-  );
-
-  const submitSearch = async () => {
-    const data = getValues();
-    let {catalog, ra, dec, radius, radius_unit} = data;
-    setSelectedCatalog(catalog);
-    // check that if positional query is requested then all required data are supplied
-    if (ra.length && dec.length && radius.length) {
-      if (ra?.length) {
-        if (ra?.includes(':') || ra?.includes('h') || ra?.includes('m') || ra?.includes('s')) {
-          ra = ra.replace(/h|m/g, ':').replace(/s/g, '');
-          ra = hours_to_ra(ra);
-        } else {
-          ra = parseFloat(ra);
-        }
-      }
-      if (dec?.length) {
-        if (dec?.includes(':') || dec?.includes('d') || dec?.includes('m') || dec?.includes('s')) {
-          dec = dec.replace(/d|m/g, ':').replace(/s/g, '');
-          dec = dms_to_dec(dec);
-        } else {
-          dec = parseFloat(dec);
-        }
-      }
-      if (Number.isNaN(parseFloat(ra)) || Number.isNaN(parseFloat(dec)) || Number.isNaN(parseFloat(radius))) {
-        dispatch(showNotification(`Invalid positional parameters`));
-        return;
-      }
-      if (radius_unit === 'arcmin') { //convert arcmin to arcsec
-        radius = parseFloat(radius) * 60;
-      } else if (radius_unit === 'deg') { //convert deg to arcsec
-        radius = parseFloat(radius) * 3600;
-      } else if (radius_unit === 'rad') { //convert rad to arcsec
-        radius = parseFloat(radius) * 206264.80624709636;
-      } else {
-        radius = parseFloat(radius);
-      }
-      dispatch(archiveActions.fetchZTFLightCurves({ catalog, ra, dec, radius }));
-      // also fetch nearest saved sources within 5 arcsec from requested position
-      dispatch(archiveActions.fetchNearestSources({ra, dec}));
-    }
-    else {
-      dispatch(showNotification(`Positional parameters must be all set`));
-    }
-  };
-
-  // save light curve data
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [saveNewSource, setSaveNewSource] = useState(false);
-
-  const createNewSourceText = "Create new source";
-
-  const validateGroups = () => {
-    const formState = getValues();
-    if (saveNewSource) {
-      return formState.group_ids.filter((value) => Boolean(value)).length >= 1;
-    }
-    return true;
-  };
-
-  const onSubmitSave = async () => {
-    setIsSubmitting(true);
-
-    const data2 = getValues2();
-
-    let objID;
-    if (data2.name && (data2.name !== '')) {
-      objID = data2.name;
-    } else {
-      objID = data2.obj_id === createNewSourceText ? null : data2.obj_id;
-    }
-
-    if (saveNewSource) {
-        let data = null;
-        const row = rows[rowsToSave.data[0].dataIndex];
-        data = await dispatch(checkSource(objID, {'ra': row.ra, 'dec': row.dec, 'nameOnly': true}));
-        if (data.data !== "A source of that name does not exist.") {
-          dispatch(showNotification(data.data, "error"));
-          setIsSubmitting(false);
-          return;
-        }
-    }
-
-    // IDs of selected groups:
-    const groupIDs = userGroupIds.filter(
-      (groupId, index) => data2.group_ids[index]
-    );
-    // IDs of selected light curves
-    const lightCurveIDs = rowsToSave.data.map(
-      // eslint-disable-next-line no-underscore-dangle
-      (rowToSave) => rows[rowToSave.dataIndex]._id
-    );
-
-    const payload = {
-      obj_id: objID,
-      catalog: selectedCatalog,
-      light_curve_ids: lightCurveIDs,
-    };
-
-    payload.group_ids = groupIDs;
-
-    const result = await dispatch(archiveActions.saveLightCurves(payload));
-    if (result.status === "success") {
-      dispatch(showNotification("Successfully saved data"));
-      handleSaveDialogClose();
-    }
-    setIsSubmitting(false);
-
-  };
-
-  // renders
-
-  if (!ZTFLightCurveCatalogNames) {
+  if (!catalogOptions) {
     return (
       <div>
         <CircularProgress color="secondary" />
@@ -562,7 +652,7 @@ const Archive = () => {
     );
   }
 
-  if (!ZTFLightCurveCatalogNames.length) {
+  if (!catalogOptions.length) {
     return (
       <div>
         <Typography variant="h5" className={classes.header}>
@@ -572,319 +662,353 @@ const Archive = () => {
     );
   }
 
-  return ZTFLightCurveCatalogNames.length &&
-    <>
-      <div>
-        <Grid
-          container
-          direction="row"
-          justifyContent="flex-start"
-          alignItems="flex-start"
-          spacing={1}
-        >
-          <Grid item xs={12} lg={10} className={classes.grid_item_table}>
-            <Paper elevation={1}>
-              <div className={classes.maindiv}>
-                <div className={classes.accordionDetails}>
-                  <StyledEngineProvider injectFirst>
-                    <ThemeProvider theme={getMuiTheme(theme)}>
-                      {queryInProgress ? <CircularProgress /> : (
-                        <MUIDataTable
-                          title="ZTF Light Curves"
-                          data={rows}
-                          columns={columns}
-                          options={options}
-                        />
-                      )}
-                    </ThemeProvider>
-                  </StyledEngineProvider>
-                </div>
-              </div>
-            </Paper>
-          </Grid>
-          <Grid item xs={12} lg={2} className={classes.grid_item_search_box}>
-            <Card className={classes.root}>
-              <form onSubmit={handleSubmitForm(submitSearch)}>
-                <CardContent className={classes.cardContent}>
-                  <FormControl required className={classes.selectEmpty}>
-                    <InputLabel name="alert-stream-select-required-label">
-                      Catalog
-                    </InputLabel>
-                    <Controller
-                      labelId="alert-stream-select-required-label"
-                      name="catalog"
-                      control={control}
-                      defaultValue={ZTFLightCurveCatalogNames[0]}
-                      rules={{ required: true }}
-                      render={({ field: { onChange, value } }) => (
-                       <Select value={value} onChange={onChange}>
-                        {ZTFLightCurveCatalogNames?.map((catalogName) => (
-                          <MenuItem key={catalogName} value={catalogName}>
-                            {catalogName}
-                          </MenuItem>
-                        ))}
-                       </Select>
-                       )}
-                      />
-                    <FormHelperText>Required</FormHelperText>
-                  </FormControl>
-              <Controller
-               render={({ field: { onChange, value } }) => (
-                <TextField
-                  margin="dense"
-                  name="ra"
-                  label="RA [deg, HH:MM:SS, HHhMMmSSs]"
-                  fullWidth
-                  inputRef={register('ra', { required: false })}
-                  value={value}
-                  onChange={onChange}
-                />
-                )}
-                name="ra"
-                control={control}
-              />
-              <Controller
-               render={({ field: { onChange, value } }) => (
-                <TextField
-                  margin="dense"
-                  name="dec"
-                  label="Dec [deg, DD:MM:SS, DDdMMmSSs]"
-                  fullWidth
-                  inputRef={register('dec', { required: false })}
-                  value={value}
-                  onChange={onChange}
-                />
-                )}
-                name="dec"
-                control={control}
-              />
-              <div style={{display: 'flex', flexDirection: 'row', justifyContent: 'space-between', gap: '0.5rem'}}>
-                <Controller
-                render={({ field: { onChange, value } }) => (
-                  <TextField
-                    margin="dense"
-                    name="radius"
-                    label="Radius"
-                    fullWidth
-                    inputRef={register('radius', { required: false })}
-                    value={value}
-                    onChange={onChange}
-                  />
-                  )}
-                  name="radius"
-                  control={control}
-                />
-                <Controller
-                  labelId="radius-unit-select-required-label"
-                  name="radius_unit"
-                  control={control}
-                  rules={{ required: true }}
-                  render={({ field: { onChange, value } }) => (
-                    <Select value={value} onChange={onChange} defaultValue="arcsec"
-                      inputRef={register('radius_unit', { required: true })}
-                      margin="dense"
-                      fullWidth
-                      style={{height: "3.5rem", marginTop: "8px", marginBottom: "4px"}}
-                    >
-                      <MenuItem value="arcsec">arcsec</MenuItem>
-                      <MenuItem value="arcmin">arcmin</MenuItem>
-                      <MenuItem value="deg">deg</MenuItem>
-                      <MenuItem value="rad">rad</MenuItem>
-                    </Select>
-                  )}
-                />
-              </div>
-                </CardContent>
-                <CardActions className={classes.cardActions}>
-                  <div className={classes.wrapperRoot}>
-                    <div className={classes.wrapper}>
-                      <Button
-                        type="submit"
-                        variant="contained"
-                        color="primary"
-                        disabled={queryInProgress}
-                      >
-                        Search
-                      </Button>
-                      {queryInProgress && <CircularProgress size={24} color="secondary" className={classes.buttonProgress} />}
-                      <IconButton
-                        aria-label="help"
-                        size="small"
-                        onClick={handleClickSearchHelp}
-                        className={classes.helpButton}
-                      >
-                        <HelpOutlineIcon />
-                      </IconButton>
-                      <StyledEngineProvider injectFirst>
-                        <ThemeProvider theme={getMuiPopoverTheme(theme)}>
-                          <Popover
-                            id={searchHelpId}
-                            open={searchHelpOpen}
-                            anchorEl={searchHeaderAnchor}
-                            onClose={handleCloseSearchHelp}
-                            anchorOrigin={{
-                              vertical: "top",
-                              horizontal: "right",
-                            }}
-                            transformOrigin={{
-                              vertical: "top",
-                              horizontal: "left",
-                            }}
-                          >
-                            <Typography className={classes.typography}>
-                              Maximum search radius is 2 degrees.<br />
-                              At most 1,000 nearest sources (to the requested position) will be returned.
-                            </Typography>
-                          </Popover>
-                        </ThemeProvider>
-                      </StyledEngineProvider>
-                    </div>
-                  </div>
-                </CardActions>
-              </form>
-            </Card>
-          </Grid>
-        </Grid>
-        <Dialog
-          fullScreen={fullScreen}
-          open={saveDialogOpen}
-          onClose={handleSaveDialogClose}
-          aria-labelledby="responsive-dialog-title"
-        >
-          <form onSubmit={handleSubmit2(onSubmitSave)}>
-            <DialogTitle id="responsive-dialog-title">
-              Save selected data to Fritz
-            </DialogTitle>
-            <DialogContent dividers>
-              <DialogContentText>
-                Post photometry data to source:
-              </DialogContentText>
-              <FormControl required>
-                <Controller
-                  name="obj_id"
-                  color="primary"
-                  render={({ field: { onChange, value } }) => (
-                    <RadioGroup
-                      color="primary"
-                      /* eslint-disable-next-line react/jsx-props-no-spreading */
-                      onChange={(event) => {
-                        onChange(event);
-                        if (event.target.value === createNewSourceText) {
-                         setSaveNewSource(true);
-                        }
-                        else {
-                         setSaveNewSource(false);
-                        }
-                      }}
-                    >
-                      {/* display list of nearby saved sources: */}
-                      {
-                        nearestSources != null && nearestSources.length > 0 &&
-                        nearestSources?.map((source) => (
-                          <FormControlLabel
-                            key={source.id}
-                            value={source.id}
-                            control={<Radio />}
-                            label={
-                              <Chip
-                                size="small"
-                                label={`${source.id} (found within 5" from search position)`}
-                                onDelete={() => window.open(`/source/${source.id}`, "_blank")}
-                                deleteIcon={<OpenInNewIcon />}
-                                color="primary"
-                              />
-                            }
+  return (
+    catalogOptions?.length && (
+      <>
+        <div>
+          <Grid
+            container
+            direction="row"
+            justifyContent="flex-start"
+            alignItems="flex-start"
+            spacing={1}
+          >
+            <Grid item xs={12} lg={10} className={classes.grid_item_table}>
+              <Paper elevation={1}>
+                <div className={classes.maindiv}>
+                  <div className={classes.accordionDetails}>
+                    <StyledEngineProvider injectFirst>
+                      <ThemeProvider theme={getMuiTheme(theme)}>
+                        {queryInProgress ? (
+                          <CircularProgress />
+                        ) : (
+                          <MUIDataTable
+                            title="ZTF Light Curves"
+                            data={rows}
+                            columns={columns}
+                            options={options}
                           />
-                        ))
-                      }
-                      <FormControlLabel value={createNewSourceText} control={<Radio />} label={createNewSourceText} />
-                    </RadioGroup>
-                  )}
-                  defaultValue={createNewSourceText}
-                  control={control2}
-                  rules={{ required: true }}
-                />
-              </FormControl>
-         <div>
-         { (saveNewSource) && (
-            <div>
-             <div>
-              <DialogContentText>
-                Source name
-              </DialogContentText>
-             </div>
-             <div>
-          <Controller
-            render={({ field: { onChange, value } }) => (
-              <TextField
-                size="small"
-                label="name"
-                name="name"
-                onChange={onChange}
-                value={value}
-              />
-            )}
-            name="name"
-            control={control2}
-          />
-          </div>
-         </div>
-        ) }
-        </div>
-              <DialogContentText className={classes.marginTop}>
-                Select groups to save new source to:
-              </DialogContentText>
-              {saveNewSource && errors.group_ids && (
-                <FormValidationError message="Select at least one group." />
-              )}
-              {userGroups.map((userGroup, idx) => (
-                <FormControlLabel
-                  key={userGroup.id}
-                  control={
+                        )}
+                      </ThemeProvider>
+                    </StyledEngineProvider>
+                  </div>
+                </div>
+              </Paper>
+            </Grid>
+            <Grid item xs={12} lg={2} className={classes.grid_item_search_box}>
+              <Card className={classes.root}>
+                <form onSubmit={handleSubmitForm(submitSearch)}>
+                  <CardContent className={classes.cardContent}>
+                    <FormControl required className={classes.selectEmpty}>
+                      <InputLabel name="alert-stream-select-required-label">
+                        Catalog
+                      </InputLabel>
+                      <Controller
+                        labelId="alert-stream-select-required-label"
+                        name="catalog"
+                        control={control}
+                        defaultValue={selectedCatalog || catalogOptions[0]}
+                        rules={{ required: true }}
+                        render={({ field: { onChange, value } }) => (
+                          <Select value={value} onChange={onChange}>
+                            {catalogOptions?.map((catalogName) => (
+                              <MenuItem key={catalogName} value={catalogName}>
+                                {catalogName}
+                              </MenuItem>
+                            ))}
+                          </Select>
+                        )}
+                      />
+                      <FormHelperText>Required</FormHelperText>
+                    </FormControl>
                     <Controller
-                      name={`group_ids[${idx}]`}
-                      control={control2}
-                      rules={{ validate: validateGroups }}
-                      defaultValue={false}
                       render={({ field: { onChange, value } }) => (
-                        <Checkbox
-                          color="primary"
-                          disabled={!saveNewSource}
-                          /* eslint-disable-next-line react/jsx-props-no-spreading */
-                          checked={value}
+                        <TextField
+                          margin="dense"
+                          name="ra"
+                          label="RA [deg, HH:MM:SS, HHhMMmSSs]"
+                          fullWidth
+                          inputRef={register("ra", { required: false })}
+                          value={value}
                           onChange={onChange}
                         />
                       )}
+                      name="ra"
+                      control={control}
                     />
-                  }
-                  label={userGroup.name}
-                />
-              ))}
-            </DialogContent>
-            <DialogActions>
-              <Button
-                variant="contained"
-                color="primary"
-                className={classes.search_button}
-                type="submit"
-                data-testid="save-dialog-submit"
-                onClick={() => onSubmitSave()}
-                disabled={isSubmitting}
-              >
-                Save
-              </Button>
-              <Button
-                autoFocus
-                onClick={handleSaveDialogClose}
-                color="primary"
-              >
-                Dismiss
-              </Button>
-            </DialogActions>
-          </form>
-        </Dialog>
-      </div>
-    </>;
+                    <Controller
+                      render={({ field: { onChange, value } }) => (
+                        <TextField
+                          margin="dense"
+                          name="dec"
+                          label="Dec [deg, DD:MM:SS, DDdMMmSSs]"
+                          fullWidth
+                          inputRef={register("dec", { required: false })}
+                          value={value}
+                          onChange={onChange}
+                        />
+                      )}
+                      name="dec"
+                      control={control}
+                    />
+                    <div
+                      style={{
+                        display: "flex",
+                        flexDirection: "row",
+                        justifyContent: "space-between",
+                        gap: "0.5rem",
+                      }}
+                    >
+                      <Controller
+                        render={({ field: { onChange, value } }) => (
+                          <TextField
+                            margin="dense"
+                            name="radius"
+                            label="Radius"
+                            fullWidth
+                            inputRef={register("radius", { required: false })}
+                            value={value}
+                            onChange={onChange}
+                          />
+                        )}
+                        name="radius"
+                        control={control}
+                      />
+                      <Controller
+                        labelId="radius-unit-select-required-label"
+                        name="radius_unit"
+                        control={control}
+                        rules={{ required: true }}
+                        render={({ field: { onChange, value } }) => (
+                          <Select
+                            value={value}
+                            onChange={onChange}
+                            defaultValue="arcsec"
+                            inputRef={register("radius_unit", {
+                              required: true,
+                            })}
+                            margin="dense"
+                            fullWidth
+                            style={{
+                              height: "3.5rem",
+                              marginTop: "8px",
+                              marginBottom: "4px",
+                            }}
+                          >
+                            <MenuItem value="arcsec">arcsec</MenuItem>
+                            <MenuItem value="arcmin">arcmin</MenuItem>
+                            <MenuItem value="deg">deg</MenuItem>
+                            <MenuItem value="rad">rad</MenuItem>
+                          </Select>
+                        )}
+                      />
+                    </div>
+                  </CardContent>
+                  <CardActions className={classes.cardActions}>
+                    <div className={classes.wrapperRoot}>
+                      <div className={classes.wrapper}>
+                        <Button
+                          type="submit"
+                          variant="contained"
+                          color="primary"
+                          disabled={queryInProgress}
+                        >
+                          Search
+                        </Button>
+                        {queryInProgress && (
+                          <CircularProgress
+                            size={24}
+                            color="secondary"
+                            className={classes.buttonProgress}
+                          />
+                        )}
+                        <IconButton
+                          aria-label="help"
+                          size="small"
+                          onClick={handleClickSearchHelp}
+                          className={classes.helpButton}
+                        >
+                          <HelpOutlineIcon />
+                        </IconButton>
+                        <StyledEngineProvider injectFirst>
+                          <ThemeProvider theme={getMuiPopoverTheme(theme)}>
+                            <Popover
+                              id={searchHelpId}
+                              open={searchHelpOpen}
+                              anchorEl={searchHeaderAnchor}
+                              onClose={handleCloseSearchHelp}
+                              anchorOrigin={{
+                                vertical: "top",
+                                horizontal: "right",
+                              }}
+                              transformOrigin={{
+                                vertical: "top",
+                                horizontal: "left",
+                              }}
+                            >
+                              <Typography className={classes.typography}>
+                                Maximum search radius is 2 degrees.
+                                <br />
+                                At most 1,000 nearest sources (to the requested
+                                position) will be returned.
+                              </Typography>
+                            </Popover>
+                          </ThemeProvider>
+                        </StyledEngineProvider>
+                      </div>
+                    </div>
+                  </CardActions>
+                </form>
+              </Card>
+            </Grid>
+          </Grid>
+          <Dialog
+            fullScreen={fullScreen}
+            open={saveDialogOpen}
+            onClose={handleSaveDialogClose}
+            aria-labelledby="responsive-dialog-title"
+          >
+            <form onSubmit={handleSubmit2(onSubmitSave)}>
+              <DialogTitle id="responsive-dialog-title">
+                Save selected data to Fritz
+              </DialogTitle>
+              <DialogContent dividers>
+                <DialogContentText>
+                  Post photometry data to source:
+                </DialogContentText>
+                <FormControl required>
+                  <Controller
+                    name="obj_id"
+                    color="primary"
+                    render={({ field: { onChange, value } }) => (
+                      <RadioGroup
+                        color="primary"
+                        /* eslint-disable-next-line react/jsx-props-no-spreading */
+                        onChange={(event) => {
+                          onChange(event);
+                          if (event.target.value === "Create new source") {
+                            setSaveNewSource(true);
+                          } else {
+                            setSaveNewSource(false);
+                          }
+                        }}
+                      >
+                        {/* display list of nearby saved sources: */}
+                        {nearestSources != null &&
+                          nearestSources.length > 0 &&
+                          nearestSources?.map((source) => (
+                            <FormControlLabel
+                              key={source.id}
+                              value={source.id}
+                              control={<Radio />}
+                              label={
+                                <Chip
+                                  size="small"
+                                  label={`${source.id} (found within 5" from search position)`}
+                                  onDelete={() =>
+                                    window.open(
+                                      `/source/${source.id}`,
+                                      "_blank",
+                                    )
+                                  }
+                                  deleteIcon={<OpenInNewIcon />}
+                                  color="primary"
+                                />
+                              }
+                            />
+                          ))}
+                        <FormControlLabel
+                          value={"Create new source"}
+                          control={<Radio />}
+                          label={"Create new source"}
+                        />
+                      </RadioGroup>
+                    )}
+                    defaultValue={"Create new source"}
+                    control={control2}
+                    rules={{ required: true }}
+                  />
+                </FormControl>
+                <div>
+                  {saveNewSource && (
+                    <div>
+                      <div>
+                        <DialogContentText>Source name</DialogContentText>
+                      </div>
+                      <div>
+                        <Controller
+                          render={({ field: { onChange, value } }) => (
+                            <TextField
+                              size="small"
+                              label="name"
+                              name="name"
+                              onChange={onChange}
+                              value={value}
+                            />
+                          )}
+                          name="name"
+                          control={control2}
+                        />
+                      </div>
+                    </div>
+                  )}
+                </div>
+                <DialogContentText className={classes.marginTop}>
+                  Select groups to save new source to:
+                </DialogContentText>
+                {saveNewSource && errors.group_ids && (
+                  <FormValidationError message="Select at least one group." />
+                )}
+                {userGroups.map((userGroup, idx) => (
+                  <FormControlLabel
+                    key={userGroup.id}
+                    control={
+                      <Controller
+                        name={`group_ids[${idx}]`}
+                        control={control2}
+                        rules={{ validate: validateGroups }}
+                        defaultValue={false}
+                        render={({ field: { onChange, value } }) => (
+                          <Checkbox
+                            color="primary"
+                            disabled={!saveNewSource}
+                            /* eslint-disable-next-line react/jsx-props-no-spreading */
+                            checked={value}
+                            onChange={onChange}
+                          />
+                        )}
+                      />
+                    }
+                    label={userGroup.name}
+                  />
+                ))}
+              </DialogContent>
+              <DialogActions>
+                <Button
+                  variant="contained"
+                  color="primary"
+                  className={classes.search_button}
+                  type="submit"
+                  data-testid="save-dialog-submit"
+                  onClick={() => onSubmitSave()}
+                  disabled={isSubmitting}
+                >
+                  Save
+                </Button>
+                <Button
+                  autoFocus
+                  onClick={handleSaveDialogClose}
+                  color="primary"
+                >
+                  Dismiss
+                </Button>
+              </DialogActions>
+            </form>
+          </Dialog>
+        </div>
+      </>
+    )
+  );
 };
 
 export default Archive;

--- a/extensions/skyportal/static/js/components/ArchiveSearchButton.jsx
+++ b/extensions/skyportal/static/js/components/ArchiveSearchButton.jsx
@@ -1,53 +1,12 @@
-import React, { useEffect } from "react";
+import React from "react";
 import PropTypes from "prop-types";
-import { useDispatch, useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 
-import { showNotification } from "baselayer/components/Notifications";
-import * as archiveActions from "../ducks/archive";
-
 const ArchiveSearchButton = ({ ra, dec, radius = 3 }) => {
-  const dispatch = useDispatch();
-  const catalogNames = useSelector((state) => state.catalog_names);
-
-  useEffect(() => {
-    const fetchCatalogNames = () => {
-      dispatch(archiveActions.fetchCatalogNames());
-    };
-    if (!catalogNames) {
-      fetchCatalogNames();
-    }
-  }, [catalogNames, dispatch]);
-
-  const ZTFLightCurveCatalogNames = Array.isArray(catalogNames)
-    ? catalogNames?.filter((name) => name.indexOf("ZTF_sources_202") !== -1)
-    : null;
-
-  const catalog = ZTFLightCurveCatalogNames
-    ? ZTFLightCurveCatalogNames[0]
-    : null;
-
-  const handleClick = () => {
-    if (catalog) {
-      dispatch(
-        archiveActions.fetchZTFLightCurves({ catalog, ra, dec, radius }),
-      );
-      dispatch(archiveActions.fetchNearestSources({ ra, dec }));
-    } else {
-      dispatch(
-        showNotification(
-          "Catalog names could not be fetched; enter search criteria manually",
-          "warning",
-        ),
-      );
-    }
-  };
-
   return (
     <Link
-      to="/archive"
+      to={`/archive?ra=${ra}&dec=${dec}&radius=${radius}`}
       target="_blank"
-      onClick={handleClick}
       style={{ textDecoration: "none", color: "black" }}
     >
      {`ZTF Light Curves (DR)`}

--- a/extensions/skyportal/static/js/components/VegaPlotZTFArchive.jsx
+++ b/extensions/skyportal/static/js/components/VegaPlotZTFArchive.jsx
@@ -6,7 +6,7 @@ import { isMobileOnly } from "react-device-detect";
 const jdNow = Date.now() / 86400000.0 + 40587. + 2400000.5;
 
 const spec = (values, colorScale) => ({
-  $schema: "https://vega.github.io/schema/vega-lite/v4.json",
+  $schema: "https://vega.github.io/schema/vega-lite/v5.2.0.json",
   width: isMobileOnly ? 250 : 500,
   height: isMobileOnly ? 150 : 250,
   data: {


### PR DESCRIPTION
* URL search params to pre-set the forms and run API query for both alerts and archival lightcurves.
* group alerts by objectID on the alerts page, to essentially get a list of objects, great for readability
* when grouping by objectID, make rows selectable to allow bulk saving of alerts as sources to a user's groups.
* cleanup the Archive page code

This PR requires https://github.com/skyportal/skyportal/pull/4830 to be merged first (once it's ready). The idea is that if one adds sources from another survey in Fritz, it's super useful to be able to grab all ZTF alerts (within a small enough radius) in Kowalski and save them, which thanks to https://github.com/skyportal/skyportal/pull/4830 allows a user to show the photometry of nearby sources on the photometry plot of any source.

TODO:
* limit the max radius that can be used when saving sources, to maybe something like 4 arcsec?
* make the pop-up window where a user saves alert(s) as source(s) smarter and more intuitive, showing info like "this source has already been saved to one or more groups".