### PR TITLE
Documentation -> server list and endpoint summary

### DIFF
--- a/extensions/skyportal/skyportal/handlers/api/alert.py
+++ b/extensions/skyportal/skyportal/handlers/api/alert.py
@@ -874,7 +874,7 @@ class AlertHandler(BaseHandler):
                 application/json:
                   schema: Error
         multiple:
-          summary: Retrieve objects from Kowalski by objectId and or position
+          summary: Retrieve objects from Kowalski by objectId/position
           description: Retrieve objects from Kowalski by objectId and or position
           tags:
             - alerts

--- a/extensions/skyportal/skyportal/handlers/api/alert.py
+++ b/extensions/skyportal/skyportal/handlers/api/alert.py
@@ -834,6 +834,7 @@ class AlertHandler(BaseHandler):
         """
         ---
         single:
+          summary: Retrieve an object from Kowalski by objectId
           description: Retrieve an object from Kowalski by objectId
           tags:
             - alerts
@@ -873,6 +874,7 @@ class AlertHandler(BaseHandler):
                 application/json:
                   schema: Error
         multiple:
+          summary: Retrieve objects from Kowalski by objectId and or position
           description: Retrieve objects from Kowalski by objectId and or position
           tags:
             - alerts
@@ -1040,6 +1042,7 @@ class AlertHandler(BaseHandler):
     def post(self, objectId):
         """
         ---
+        summary: Save ZTF objectId from Kowalski as source in SkyPortal
         description: Save ZTF objectId from Kowalski as source in SkyPortal
         tags:
           - alerts
@@ -1126,6 +1129,7 @@ class AlertAuxHandler(BaseHandler):
         """
         ---
         single:
+          summary: Retrieve aux data for an objectId from Kowalski
           description: Retrieve aux data for an objectId from Kowalski
           tags:
             - alerts
@@ -1400,6 +1404,7 @@ class AlertCutoutHandler(BaseHandler):
         """
         ---
         summary: Serve alert cutout as fits or png
+        description: Serve alert cutout as fits or png
         tags:
           - alerts
           - kowalski
@@ -1609,6 +1614,7 @@ class AlertTripletsHandler(BaseHandler):
         """
         ---
         summary: Serve alert cutouts as a triplet
+        description: Serve alert cutouts as a triplet
         tags:
           - alerts
           - kowalski
@@ -1767,6 +1773,7 @@ class AlertStatsHandler(BaseHandler):
         """
         ---
         summary: Get number of alerts in a time range
+        description: Get number of alerts in a time range
         tags:
           - alerts
           - kowalski

--- a/extensions/skyportal/skyportal/handlers/api/archive.py
+++ b/extensions/skyportal/skyportal/handlers/api/archive.py
@@ -147,7 +147,7 @@ class ArchiveCatalogsHandler(BaseHandler):
     def get(self):
         """
         ---
-        summary: Retrieve available catalog names from Kowalski/Gloria/Melman
+        summary: Retrieve available catalog names from Kowalski
         description: Retrieve available catalog names from Kowalski/Gloria/Melman
         tags:
           - archive
@@ -187,7 +187,7 @@ class CrossMatchHandler(BaseHandler):
     def get(self):
         """
         ---
-        summary: Retrieve data from available catalogs on Kowalski/Gloria/Melman by position
+        summary: Retrieve data from available catalogs in Kowalski by position
         description: Retrieve data from available catalogs on Kowalski/Gloria/Melman by position
         tags:
           - archive
@@ -365,7 +365,7 @@ class ScopeFeaturesHandler(BaseHandler):
     def post(self):
         """
         ---
-        summary: Retrieve archival SCoPe features from Kowalski/Gloria/Melman by position, post as annotation
+        summary: Retrieve archival SCoPe features by position, post as annotation
         description: Retrieve archival SCoPe features from Kowalski/Gloria/Melman by position, post as annotation
         tags:
           - features
@@ -628,7 +628,7 @@ class ArchiveHandler(BaseHandler):
     def get(self, lc_id=None):
         """
         ---
-        summary: Retrieve archival light curve data from Kowalski/Gloria by position
+        summary: Retrieve archival light curve data by position
         description: Retrieve archival light curve data from Kowalski/Gloria by position
         tags:
           - archive

--- a/extensions/skyportal/skyportal/handlers/api/archive.py
+++ b/extensions/skyportal/skyportal/handlers/api/archive.py
@@ -148,6 +148,7 @@ class ArchiveCatalogsHandler(BaseHandler):
         """
         ---
         summary: Retrieve available catalog names from Kowalski/Gloria/Melman
+        description: Retrieve available catalog names from Kowalski/Gloria/Melman
         tags:
           - archive
           - kowalski
@@ -187,6 +188,7 @@ class CrossMatchHandler(BaseHandler):
         """
         ---
         summary: Retrieve data from available catalogs on Kowalski/Gloria/Melman by position
+        description: Retrieve data from available catalogs on Kowalski/Gloria/Melman by position
         tags:
           - archive
           - kowalski
@@ -364,6 +366,7 @@ class ScopeFeaturesHandler(BaseHandler):
         """
         ---
         summary: Retrieve archival SCoPe features from Kowalski/Gloria/Melman by position, post as annotation
+        description: Retrieve archival SCoPe features from Kowalski/Gloria/Melman by position, post as annotation
         tags:
           - features
           - kowalski
@@ -626,6 +629,7 @@ class ArchiveHandler(BaseHandler):
         """
         ---
         summary: Retrieve archival light curve data from Kowalski/Gloria by position
+        description: Retrieve archival light curve data from Kowalski/Gloria by position
         tags:
           - archive
           - kowalski

--- a/extensions/skyportal/skyportal/handlers/api/db_stats.py
+++ b/extensions/skyportal/skyportal/handlers/api/db_stats.py
@@ -54,6 +54,7 @@ class StatsHandler(BaseHandler):
     def get(self):
         """
         ---
+        summary: Retrieve basic DB statistics
         description: Retrieve basic DB statistics
         tags:
           - system_info

--- a/extensions/skyportal/skyportal/handlers/api/kowalski_filter.py
+++ b/extensions/skyportal/skyportal/handlers/api/kowalski_filter.py
@@ -34,6 +34,7 @@ class KowalskiFilterHandler(BaseHandler):
         """
         ---
         single:
+          summary: Retrieve a filter as stored on Kowalski
           description: Retrieve a filter as stored on Kowalski
           tags:
             - filters
@@ -96,6 +97,7 @@ class KowalskiFilterHandler(BaseHandler):
     def post(self, filter_id):
         """
         ---
+        summary: POST a new filter version
         description: POST a new filter version.
         tags:
           - filters
@@ -176,6 +178,7 @@ class KowalskiFilterHandler(BaseHandler):
     def patch(self, filter_id):
         """
         ---
+        summary: Update a filter on Kowalski
         description: Update a filter on Kowalski
         tags:
           - filters
@@ -411,6 +414,7 @@ class KowalskiFilterHandler(BaseHandler):
     def delete(self, filter_id):
         """
         ---
+        summary: Delete a filter on Kowalski
         description: Delete a filter on Kowalski
         tags:
           - filters

--- a/fritz.defaults.yaml
+++ b/fritz.defaults.yaml
@@ -2011,3 +2011,10 @@ kowalski:
     pgir: True
     wntr: True
     turbo: True
+
+docs:
+  servers:
+    - url: https://fritz.science
+      description: Production server
+    - url: https://preview.fritz.science
+      description: Test server


### PR DESCRIPTION
This PR:
- adds fritz.science and preview.fritz.science as the list of servers to include in the auto-generated openapi specification.
- adds a `summary` to all of the endpoints Fritz adds on top of SkyPortal. This is required if we want to have a nice text rather than the raw URL shown in the list of endpoints on the left of the API documentation page.