### PR TITLE
Kowalski Filter - not_if_tns_reported

### DIFF
--- a/extensions/skyportal/skyportal/handlers/api/kowalski_filter.py
+++ b/extensions/skyportal/skyportal/handlers/api/kowalski_filter.py
@@ -352,11 +352,30 @@ class KowalskiFilterHandler(BaseHandler):
                 "radius",
                 "implements_update",
                 "ignore_allocation_ids",
+                "not_if_tns_reported",
             }
             if not set(auto_followup.keys()).issubset(valid_keys):
                 return self.error(
                     f"auto_followup dict keys must be a subset of {valid_keys}"
                 )
+            if "not_if_tns_reported" in auto_followup:
+                # if it's not empty or None, verify it's a a float or an int
+                if (
+                    auto_followup["not_if_tns_reported"] is not None
+                    and str(auto_followup["not_if_tns_reported"]).strip() != ""
+                ):
+                    try:
+                        auto_followup["not_if_tns_reported"] = float(
+                            auto_followup["not_if_tns_reported"]
+                        )
+                    except ValueError:
+                        return self.error(
+                            "not_if_tns_reported must be a float or an int, if not an empty string or None"
+                        )
+                else:
+                    # we still want to keep it when None, for example when we want to unset it
+                    auto_followup["not_if_tns_reported"] = None
+
             # query the allocation by id
             allocation_id = auto_followup.get("allocation_id", None)
 

--- a/extensions/skyportal/skyportal/handlers/api/kowalski_filter.py
+++ b/extensions/skyportal/skyportal/handlers/api/kowalski_filter.py
@@ -360,6 +360,7 @@ class KowalskiFilterHandler(BaseHandler):
                 )
             if "not_if_tns_reported" in auto_followup:
                 # if it's not empty or None, verify it's a a float or an int
+                # it should be in hours
                 if (
                     auto_followup["not_if_tns_reported"] is not None
                     and str(auto_followup["not_if_tns_reported"]).strip() != ""

--- a/extensions/skyportal/static/js/components/filter/FilterPlugins.jsx
+++ b/extensions/skyportal/static/js/components/filter/FilterPlugins.jsx
@@ -180,6 +180,7 @@ const FilterPlugins = ({ group }) => {
   const [autosaveComment, setAutosaveComment] = useState("");
   const [autoFollowupComment, setAutoFollowupComment] = useState("");
   const [autoFollowupRadius, setAutoFollowupRadius] = useState(0.5);
+  const [autoFollowupTnsAge, setAutoFollowupTnsAge] = useState(null);
 
   const [otherVersion, setOtherVersion] = React.useState("");
 
@@ -321,6 +322,7 @@ const FilterPlugins = ({ group }) => {
     const newAutoFollowup = {
       ...filter_v.auto_followup,
       radius: autoFollowupRadius,
+      not_if_tns_reported: autoFollowupTnsAge,
     };
     const result = await dispatch(
       filterVersionActions.editAutoFollowup({
@@ -331,7 +333,7 @@ const FilterPlugins = ({ group }) => {
     if (result.status === "success") {
       dispatch(
         showNotification(
-          `Set auto_followup radius constraint to ${autoFollowupRadius}`,
+          `Set auto_followup radius constraint to ${autoFollowupRadius}, and TNS age constraint to ${autoFollowupTnsAge}`,
         ),
       );
     }
@@ -1567,6 +1569,21 @@ const FilterPlugins = ({ group }) => {
                         defaultValue={filter_v.auto_followup?.radius}
                         onChange={(event) =>
                           setAutoFollowupRadius(event.target.value)
+                        }
+                      />
+                    </div>
+                    <div style={{ marginTop: "1rem" }}>
+                      <InputLabel id="auto_followup_constraints_tns_age">
+                        Cancel if TNS reported in the last N hours. Leave empty to disable
+                      </InputLabel>
+                      <TextField
+                        labelId="auto_followup_constraints_tns_age"
+                        className={classes.formControl}
+                        disabled={!filter_v.active}
+                        id="auto_followup_constraints_tns_age"
+                        defaultValue={filter_v.auto_followup?.not_if_tns_reported}
+                        onChange={(event) =>
+                          setAutoFollowupTnsAge(event.target.value)
                         }
                       />
                     </div>

--- a/fritz.defaults.yaml
+++ b/fritz.defaults.yaml
@@ -62,6 +62,11 @@ skyportal:
       host:
       port:
 
+    gemini:
+      protocol: https
+      host: gsodbtest.gemini.edu # this is the test server host, just remove 'test' for production
+      port: 8443 # this is the test server port, production is 443
+
     treasuremap_endpoint: https://treasuremap.space
 
     tns:


### PR DESCRIPTION
Add support for a new SkyPortal follow-up constraint (https://github.com/skyportal/skyportal/pull/5317) that can be used with Kowalski's auto triggering feature (https://github.com/skyportal/kowalski/pull/444).

This PR adds the API code to support it and validate its value, and adds the frontend required to edit it.