### PR TITLE
alert.py: minor improvements

### DIFF
--- a/extensions/skyportal/skyportal/handlers/api/alert.py
+++ b/extensions/skyportal/skyportal/handlers/api/alert.py
@@ -43,6 +43,7 @@ from ...models import (
     Stream,
     User,
 )
+from ...utils.parse import str_to_bool
 from ..base import BaseHandler
 from .photometry import add_external_photometry
 from .thumbnail import post_thumbnail
@@ -1192,11 +1193,13 @@ class AlertAuxHandler(BaseHandler):
         selector = list(selector)
 
         include_prv_candidates = self.get_query_argument("includePrvCandidates", "true")
-        include_prv_candidates = include_prv_candidates.lower() != "true"
+        include_prv_candidates = str_to_bool(include_prv_candidates, default=True)
+
         include_fp_hists = self.get_query_argument("includeFpHists", "true")
-        include_fp_hists = include_fp_hists.lower() == "true"
+        include_fp_hists = str_to_bool(include_fp_hists, default=True)
+
         include_all_fields = self.get_query_argument("includeAllFields", "false")
-        include_all_fields = include_all_fields.lower() != "false"
+        include_all_fields = str_to_bool(include_all_fields.lower(), default=False)
 
         try:
             query = {


### PR DESCRIPTION
In this PR we:
- add a decorator on top of each kowalski-related endpoints in `alert.py` which checks if kowalski is available. If it isn't then it tries to connect again before proceeding with the API call itself
- wrapped the Kowalski instantiation in a method that can be called by the decorator
- refactored the ztf alert cutouts import in a separate method
- cleaned up some of the code here and there, avoiding unnecessary operations and writes to disk when creating thumbnails

The original plan was to improve on performance but first it would be good to make the code a bit more robust to avoid running in some errors and such. There is still more work needed but this is a good first step.