### PR TITLE
fix unexpected keyword argument nsamples

### DIFF
--- a/extensions/skyportal/skyportal/handlers/api/kowalski/alert.py
+++ b/extensions/skyportal/skyportal/handlers/api/kowalski/alert.py
@@ -1528,7 +1528,7 @@ class AlertCutoutHandler(BaseHandler):
                     lower_percentile=1, upper_percentile=100
                 ),
                 "min_max": MinMaxInterval(),
-                "zscale": ZScaleInterval(nsamples=600, contrast=0.045, krej=2.5),
+                "zscale": ZScaleInterval(n_samples=600, contrast=0.045, krej=2.5),
             }
             if interval is None:
                 interval = "asymmetric_percentile"


### PR DESCRIPTION
Correct the keyword argument from `nsamples` to `n_samples` in `ZScaleInterval` in `alert.py` to avoid the following error:

```
failure: Traceback (most recent call last):
  File "/skyportal/skyportal/handlers/api/kowalski/alert.py", line 1531, in get
    "zscale": ZScaleInterval(nsamples=600, contrast=0.045, krej=2.5),
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: ZScaleInterval.__init__() got an unexpected keyword argument 'nsamples'
```

This occurs when calling the thumbnails handler (e.g., [https://fritz.science/api/alerts_cutouts?objectId=ZTF25aaxmsns&candid=3105344563415015001&cutout=template](https://fritz.science/api/alerts_cutouts?objectId=ZTF25aaxmsns&candid=3105344563415015001&cutout=template)).
