### PR TITLE
Fix Boom tests

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -111,6 +111,11 @@ jobs:
                 - /app/kafka_consumer
                 - ztf
                 - "20240617"
+            consumer-ztf-partnership:
+               environment:
+                 BOOM_API__AUTH__SECRET_KEY: ${BOOM_API__AUTH__SECRET_KEY}
+                 BOOM_API__AUTH__ADMIN_PASSWORD: ${BOOM_API__AUTH__ADMIN_PASSWORD}
+                 BOOM_KAFKA__CONSUMER__ZTF__SERVER: broker:29092
             scheduler-ztf:
               environment:
                 BOOM_API__AUTH__SECRET_KEY: ${BOOM_API__AUTH__SECRET_KEY}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -132,6 +132,8 @@ jobs:
                 BOOM_API__AUTH__SECRET_KEY: ${BOOM_API__AUTH__SECRET_KEY}
                 BOOM_API__AUTH__ADMIN_PASSWORD: ${BOOM_API__AUTH__ADMIN_PASSWORD}
                 BOOM_KAFKA__CONSUMER__LSST__SERVER: broker:29092
+                BOOM_KAFKA__CONSUMER__LSST__USERNAME: ${BOOM_KAFKA__CONSUMER__LSST__USERNAME}
+                BOOM_KAFKA__CONSUMER__LSST__PASSWORD: ${BOOM_KAFKA__CONSUMER__LSST__PASSWORD}
             scheduler-lsst:
               environment:
                 BOOM_API__AUTH__SECRET_KEY: ${BOOM_API__AUTH__SECRET_KEY}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -97,7 +97,7 @@ jobs:
                 # matching too many alerts in a small (~100-alert) seed.
                 BOOM_WORKERS__ZTF__FILTER__REFERENCE_NIGHT: "${BOOM_WORKERS__ZTF__FILTER__REFERENCE_NIGHT}"
                 BOOM_WORKERS__ZTF__FILTER__MAX_MATCH_RATE: "${BOOM_WORKERS__ZTF__FILTER__MAX_MATCH_RATE}"
-            consumer-ztf:
+            consumer-ztf-public:
               environment:
                 BOOM_API__AUTH__SECRET_KEY: ${BOOM_API__AUTH__SECRET_KEY}
                 BOOM_API__AUTH__ADMIN_PASSWORD: ${BOOM_API__AUTH__ADMIN_PASSWORD}
@@ -112,6 +112,11 @@ jobs:
                 - ztf
                 - "20240617"
             consumer-ztf-partnership:
+               environment:
+                 BOOM_API__AUTH__SECRET_KEY: ${BOOM_API__AUTH__SECRET_KEY}
+                 BOOM_API__AUTH__ADMIN_PASSWORD: ${BOOM_API__AUTH__ADMIN_PASSWORD}
+                 BOOM_KAFKA__CONSUMER__ZTF__SERVER: broker:29092
+            consumer-ztf-caltech:
                environment:
                  BOOM_API__AUTH__SECRET_KEY: ${BOOM_API__AUTH__SECRET_KEY}
                  BOOM_API__AUTH__ADMIN_PASSWORD: ${BOOM_API__AUTH__ADMIN_PASSWORD}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -159,6 +159,7 @@ jobs:
           BOOM_KAFKA__CONSUMER__LSST__GROUP_ID: boom-lsst-consumer-group
           BOOM_KAFKA__CONSUMER__LSST__USERNAME: lsst_user
           BOOM_KAFKA__CONSUMER__LSST__PASSWORD: lsst_password
+          BOOM_KAFKA__CONSUMER__ZTF__SERVER: broker:29092
           # Filter activation validation: boom's default reference_night is
           # 2026-03-16, but our seed dataset is 2024-06-17. Without this
           # override, POST /filters returns 400 because no alerts exist on

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -156,10 +156,11 @@ jobs:
           KAFKA_ADMIN_PASSWORD: ci-kafka-admin
           KAFKA_READONLY_PASSWORD: ci-kafka-readonly
           BOOM_KAFKA__CONSUMER__ZTF__GROUP_ID: boom-ztf-consumer-group
+          BOOM_KAFKA__CONSUMER__ZTF__SERVER: broker:29092
           BOOM_KAFKA__CONSUMER__LSST__GROUP_ID: boom-lsst-consumer-group
           BOOM_KAFKA__CONSUMER__LSST__USERNAME: lsst_user
           BOOM_KAFKA__CONSUMER__LSST__PASSWORD: lsst_password
-          BOOM_KAFKA__CONSUMER__ZTF__SERVER: broker:29092
+          BOOM_KAFKA__CONSUMER__LSST__SERVER: broker:29092
           # Filter activation validation: boom's default reference_night is
           # 2026-03-16, but our seed dataset is 2024-06-17. Without this
           # override, POST /filters returns 400 because no alerts exist on

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -131,6 +131,7 @@ jobs:
               environment:
                 BOOM_API__AUTH__SECRET_KEY: ${BOOM_API__AUTH__SECRET_KEY}
                 BOOM_API__AUTH__ADMIN_PASSWORD: ${BOOM_API__AUTH__ADMIN_PASSWORD}
+                BOOM_KAFKA__CONSUMER__LSST__SERVER: broker:29092
             scheduler-lsst:
               environment:
                 BOOM_API__AUTH__SECRET_KEY: ${BOOM_API__AUTH__SECRET_KEY}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -132,8 +132,8 @@ jobs:
                 BOOM_API__AUTH__SECRET_KEY: ${BOOM_API__AUTH__SECRET_KEY}
                 BOOM_API__AUTH__ADMIN_PASSWORD: ${BOOM_API__AUTH__ADMIN_PASSWORD}
                 BOOM_KAFKA__CONSUMER__LSST__SERVER: broker:29092
-                BOOM_KAFKA__CONSUMER__LSST__USERNAME: ${BOOM_KAFKA__CONSUMER__LSST__USERNAME}
-                BOOM_KAFKA__CONSUMER__LSST__PASSWORD: ${BOOM_KAFKA__CONSUMER__LSST__PASSWORD}
+                BOOM_KAFKA__CONSUMER__LSST__USERNAME: lsst_user
+                BOOM_KAFKA__CONSUMER__LSST__PASSWORD: lsst_password
             scheduler-lsst:
               environment:
                 BOOM_API__AUTH__SECRET_KEY: ${BOOM_API__AUTH__SECRET_KEY}

--- a/extensions/skyportal/static/js/components/alert/Alert.tsx
+++ b/extensions/skyportal/static/js/components/alert/Alert.tsx
@@ -38,8 +38,11 @@ import withRouter from "../withRouter";
 import { ra_to_hours, dec_to_dms } from "../../units";
 
 import * as Actions from "../../ducks/boom_alert";
-import { checkSource, fetchSource } from "../../ducks/source";
-import { fetchSources } from "../../ducks/sources";
+import {
+  useLazyCheckSourceQuery,
+  useLazyGetSourceQuery,
+} from "../../ducks/source";
+import { useLazyFetchSourcesQuery } from "../../ducks/sources";
 import { bytes2image } from "../../utils/imageProcessing";
 
 // ── Survey inference ──────────────────────────────────────────────────────────
@@ -494,6 +497,10 @@ const Alert = ({ route }: AlertProps) => {
   const [savedSource, setSavedSource] = useState(false);
   const [fetchedDuplicates, setFetchedDuplicates] = useState(false);
 
+  const [triggerCheckSource] = useLazyCheckSourceQuery();
+  const [triggerGetSource] = useLazyGetSourceQuery();
+  const [triggerFetchSources] = useLazyFetchSourcesQuery();
+
   const sources = useAppSelector((state) => (state as any).sources.latest);
   const source = useAppSelector((state) => (state as any).source);
   const loadedSourceId = useAppSelector((state) => (state as any)?.source?.id);
@@ -575,25 +582,25 @@ const Alert = ({ route }: AlertProps) => {
 
   // ── Source existence check ──────────────────────────────────────────────────
   useEffect(() => {
-    const fetchExistingSource = () => {
-      dispatch(checkSource(objectId, { nameOnly: true })).then(
-        (response: any) => {
-          if (
-            response.status === "success" &&
-            response.data?.source_exists === true
-          ) {
-            setSavedSource(true);
-            dispatch(fetchSource(objectId));
-          } else {
-            setSavedSource(false);
-          }
-        },
-      );
+    const fetchExistingSource = async () => {
+      const result = await triggerCheckSource({
+        id: objectId,
+        params: { nameOnly: true },
+      });
+      if (
+        result.data?.status === "success" &&
+        result.data?.data?.source_exists === true
+      ) {
+        setSavedSource(true);
+        triggerGetSource(objectId);
+      } else {
+        setSavedSource(false);
+      }
     };
     if (objectId !== loadedSourceId) {
       fetchExistingSource();
     }
-  }, [dispatch, objectId]);
+  }, [objectId]);
 
   // ── Alert data fetch ────────────────────────────────────────────────────────
   const isCached =
@@ -632,11 +639,8 @@ const Alert = ({ route }: AlertProps) => {
       const ra = getRa(lastAlert);
       const dec = getDec(lastAlert);
       if (ra != null && dec != null) {
-        dispatch(fetchSources({ ra, dec, radius: 2 / 3600 })).then(
-          (response: any) => {
-            if (response.status === "success") setFetchedDuplicates(true);
-          },
-        );
+        const result = await triggerFetchSources({ ra, dec, radius: 2 / 3600 });
+        if (result.data?.status === "success") setFetchedDuplicates(true);
       }
     };
 

--- a/extensions/skyportal/static/js/components/alert/SaveAlertButton.tsx
+++ b/extensions/skyportal/static/js/components/alert/SaveAlertButton.tsx
@@ -22,7 +22,7 @@ import { useAppDispatch, useAppSelector } from "../../types/hooks";
 import FormValidationError from "../FormValidationError";
 
 import * as alertActions from "../../ducks/boom_alert";
-import * as sourceActions from "../../ducks/source";
+import { useLazyGetSourceQuery } from "../../ducks/source";
 
 interface SaveAlertButtonProps {
   alert: any;
@@ -34,6 +34,7 @@ const SaveAlertButton = ({ alert, userGroups }: SaveAlertButtonProps) => {
   // Dialog logic:
 
   const dispatch = useAppDispatch();
+  const [triggerGetSource] = useLazyGetSourceQuery();
   const [dialogOpen, setDialogOpen] = useState(false);
   const source = useAppSelector((state) => (state as any).source);
   const groups = (
@@ -107,7 +108,7 @@ const SaveAlertButton = ({ alert, userGroups }: SaveAlertButtonProps) => {
       setIsSubmitting(false);
       setDialogOpen(false);
       reset();
-      await dispatch(sourceActions.fetchSource(alert.id));
+      triggerGetSource(alert.id);
     }
   };
 


### PR DESCRIPTION
The skyportal submodule bump pulled in the RTK Query migration, which removed fetchSource, checkSource, and fetchSources as dispatchable thunks from ducks/source.ts / ducks/sources.ts. The BOOM Alert.tsx and SaveAlertButton.tsx still imported and called them, so the Alert component crashed on mount with a TypeError — rendering nothing, causing all frontend test assertions to time out.

Fix: Replace the three removed thunk imports with their RTK Query equivalents (useLazyGetSourceQuery, useLazyCheckSourceQuery, useLazyFetchSourcesQuery) and update the call sites in Alert.tsx and SaveAlertButton.tsx to use the lazy hook trigger pattern instead of dispatch.