### PR TITLE
Fix BOOM alert pages crashing under RTK Query (builds on #588)

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -111,6 +111,11 @@ jobs:
                 - /app/kafka_consumer
                 - ztf
                 - "20240617"
+            consumer-ztf-partnership:
+               environment:
+                 BOOM_API__AUTH__SECRET_KEY: ${BOOM_API__AUTH__SECRET_KEY}
+                 BOOM_API__AUTH__ADMIN_PASSWORD: ${BOOM_API__AUTH__ADMIN_PASSWORD}
+                 BOOM_KAFKA__CONSUMER__ZTF__SERVER: broker:29092
             scheduler-ztf:
               environment:
                 BOOM_API__AUTH__SECRET_KEY: ${BOOM_API__AUTH__SECRET_KEY}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -132,6 +132,8 @@ jobs:
                 BOOM_API__AUTH__SECRET_KEY: ${BOOM_API__AUTH__SECRET_KEY}
                 BOOM_API__AUTH__ADMIN_PASSWORD: ${BOOM_API__AUTH__ADMIN_PASSWORD}
                 BOOM_KAFKA__CONSUMER__LSST__SERVER: broker:29092
+                BOOM_KAFKA__CONSUMER__LSST__USERNAME: ${BOOM_KAFKA__CONSUMER__LSST__USERNAME}
+                BOOM_KAFKA__CONSUMER__LSST__PASSWORD: ${BOOM_KAFKA__CONSUMER__LSST__PASSWORD}
             scheduler-lsst:
               environment:
                 BOOM_API__AUTH__SECRET_KEY: ${BOOM_API__AUTH__SECRET_KEY}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -97,7 +97,7 @@ jobs:
                 # matching too many alerts in a small (~100-alert) seed.
                 BOOM_WORKERS__ZTF__FILTER__REFERENCE_NIGHT: "${BOOM_WORKERS__ZTF__FILTER__REFERENCE_NIGHT}"
                 BOOM_WORKERS__ZTF__FILTER__MAX_MATCH_RATE: "${BOOM_WORKERS__ZTF__FILTER__MAX_MATCH_RATE}"
-            consumer-ztf:
+            consumer-ztf-public:
               environment:
                 BOOM_API__AUTH__SECRET_KEY: ${BOOM_API__AUTH__SECRET_KEY}
                 BOOM_API__AUTH__ADMIN_PASSWORD: ${BOOM_API__AUTH__ADMIN_PASSWORD}
@@ -112,6 +112,11 @@ jobs:
                 - ztf
                 - "20240617"
             consumer-ztf-partnership:
+               environment:
+                 BOOM_API__AUTH__SECRET_KEY: ${BOOM_API__AUTH__SECRET_KEY}
+                 BOOM_API__AUTH__ADMIN_PASSWORD: ${BOOM_API__AUTH__ADMIN_PASSWORD}
+                 BOOM_KAFKA__CONSUMER__ZTF__SERVER: broker:29092
+            consumer-ztf-caltech:
                environment:
                  BOOM_API__AUTH__SECRET_KEY: ${BOOM_API__AUTH__SECRET_KEY}
                  BOOM_API__AUTH__ADMIN_PASSWORD: ${BOOM_API__AUTH__ADMIN_PASSWORD}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -159,6 +159,7 @@ jobs:
           BOOM_KAFKA__CONSUMER__LSST__GROUP_ID: boom-lsst-consumer-group
           BOOM_KAFKA__CONSUMER__LSST__USERNAME: lsst_user
           BOOM_KAFKA__CONSUMER__LSST__PASSWORD: lsst_password
+          BOOM_KAFKA__CONSUMER__ZTF__SERVER: broker:29092
           # Filter activation validation: boom's default reference_night is
           # 2026-03-16, but our seed dataset is 2024-06-17. Without this
           # override, POST /filters returns 400 because no alerts exist on

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -156,10 +156,11 @@ jobs:
           KAFKA_ADMIN_PASSWORD: ci-kafka-admin
           KAFKA_READONLY_PASSWORD: ci-kafka-readonly
           BOOM_KAFKA__CONSUMER__ZTF__GROUP_ID: boom-ztf-consumer-group
+          BOOM_KAFKA__CONSUMER__ZTF__SERVER: broker:29092
           BOOM_KAFKA__CONSUMER__LSST__GROUP_ID: boom-lsst-consumer-group
           BOOM_KAFKA__CONSUMER__LSST__USERNAME: lsst_user
           BOOM_KAFKA__CONSUMER__LSST__PASSWORD: lsst_password
-          BOOM_KAFKA__CONSUMER__ZTF__SERVER: broker:29092
+          BOOM_KAFKA__CONSUMER__LSST__SERVER: broker:29092
           # Filter activation validation: boom's default reference_night is
           # 2026-03-16, but our seed dataset is 2024-06-17. Without this
           # override, POST /filters returns 400 because no alerts exist on

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -131,6 +131,7 @@ jobs:
               environment:
                 BOOM_API__AUTH__SECRET_KEY: ${BOOM_API__AUTH__SECRET_KEY}
                 BOOM_API__AUTH__ADMIN_PASSWORD: ${BOOM_API__AUTH__ADMIN_PASSWORD}
+                BOOM_KAFKA__CONSUMER__LSST__SERVER: broker:29092
             scheduler-lsst:
               environment:
                 BOOM_API__AUTH__SECRET_KEY: ${BOOM_API__AUTH__SECRET_KEY}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -132,8 +132,8 @@ jobs:
                 BOOM_API__AUTH__SECRET_KEY: ${BOOM_API__AUTH__SECRET_KEY}
                 BOOM_API__AUTH__ADMIN_PASSWORD: ${BOOM_API__AUTH__ADMIN_PASSWORD}
                 BOOM_KAFKA__CONSUMER__LSST__SERVER: broker:29092
-                BOOM_KAFKA__CONSUMER__LSST__USERNAME: ${BOOM_KAFKA__CONSUMER__LSST__USERNAME}
-                BOOM_KAFKA__CONSUMER__LSST__PASSWORD: ${BOOM_KAFKA__CONSUMER__LSST__PASSWORD}
+                BOOM_KAFKA__CONSUMER__LSST__USERNAME: lsst_user
+                BOOM_KAFKA__CONSUMER__LSST__PASSWORD: lsst_password
             scheduler-lsst:
               environment:
                 BOOM_API__AUTH__SECRET_KEY: ${BOOM_API__AUTH__SECRET_KEY}

--- a/extensions/skyportal/static/js/components/alert/Alert.tsx
+++ b/extensions/skyportal/static/js/components/alert/Alert.tsx
@@ -38,8 +38,11 @@ import withRouter from "../withRouter";
 import { ra_to_hours, dec_to_dms } from "../../units";
 
 import * as Actions from "../../ducks/boom_alert";
-import { checkSource, fetchSource } from "../../ducks/source";
-import { fetchSources } from "../../ducks/sources";
+import {
+  useLazyCheckSourceQuery,
+  useLazyGetSourceQuery,
+} from "../../ducks/source";
+import { useLazyFetchSourcesQuery } from "../../ducks/sources";
 import { bytes2image } from "../../utils/imageProcessing";
 
 // ── Survey inference ──────────────────────────────────────────────────────────
@@ -494,6 +497,10 @@ const Alert = ({ route }: AlertProps) => {
   const [savedSource, setSavedSource] = useState(false);
   const [fetchedDuplicates, setFetchedDuplicates] = useState(false);
 
+  const [triggerCheckSource] = useLazyCheckSourceQuery();
+  const [triggerGetSource] = useLazyGetSourceQuery();
+  const [triggerFetchSources] = useLazyFetchSourcesQuery();
+
   const sources = useAppSelector((state) => (state as any).sources.latest);
   const source = useAppSelector((state) => (state as any).source);
   const loadedSourceId = useAppSelector((state) => (state as any)?.source?.id);
@@ -575,25 +582,25 @@ const Alert = ({ route }: AlertProps) => {
 
   // ── Source existence check ──────────────────────────────────────────────────
   useEffect(() => {
-    const fetchExistingSource = () => {
-      dispatch(checkSource(objectId, { nameOnly: true })).then(
-        (response: any) => {
-          if (
-            response.status === "success" &&
-            response.data?.source_exists === true
-          ) {
-            setSavedSource(true);
-            dispatch(fetchSource(objectId));
-          } else {
-            setSavedSource(false);
-          }
-        },
-      );
+    const fetchExistingSource = async () => {
+      const result = await triggerCheckSource({
+        id: objectId,
+        params: { nameOnly: true },
+      });
+      if (
+        result.data?.status === "success" &&
+        result.data?.data?.source_exists === true
+      ) {
+        setSavedSource(true);
+        triggerGetSource(objectId);
+      } else {
+        setSavedSource(false);
+      }
     };
     if (objectId !== loadedSourceId) {
       fetchExistingSource();
     }
-  }, [dispatch, objectId]);
+  }, [objectId]);
 
   // ── Alert data fetch ────────────────────────────────────────────────────────
   const isCached =
@@ -632,11 +639,8 @@ const Alert = ({ route }: AlertProps) => {
       const ra = getRa(lastAlert);
       const dec = getDec(lastAlert);
       if (ra != null && dec != null) {
-        dispatch(fetchSources({ ra, dec, radius: 2 / 3600 })).then(
-          (response: any) => {
-            if (response.status === "success") setFetchedDuplicates(true);
-          },
-        );
+        const result = await triggerFetchSources({ ra, dec, radius: 2 / 3600 });
+        if (result.data?.status === "success") setFetchedDuplicates(true);
       }
     };
 

--- a/extensions/skyportal/static/js/components/alert/Alert.tsx
+++ b/extensions/skyportal/static/js/components/alert/Alert.tsx
@@ -43,6 +43,7 @@ import {
   useLazyGetSourceQuery,
 } from "../../ducks/source";
 import { useLazyFetchSourcesQuery } from "../../ducks/sources";
+import { useGetGroupsQuery } from "../../ducks/groups";
 import { bytes2image } from "../../utils/imageProcessing";
 
 // ── Survey inference ──────────────────────────────────────────────────────────
@@ -498,15 +499,14 @@ const Alert = ({ route }: AlertProps) => {
   const [fetchedDuplicates, setFetchedDuplicates] = useState(false);
 
   const [triggerCheckSource] = useLazyCheckSourceQuery();
-  const [triggerGetSource] = useLazyGetSourceQuery();
-  const [triggerFetchSources] = useLazyFetchSourcesQuery();
+  const [triggerGetSource, getSourceResult] = useLazyGetSourceQuery();
+  const [triggerFetchSources, fetchSourcesResult] = useLazyFetchSourcesQuery();
 
-  const sources = useAppSelector((state) => (state as any).sources.latest);
-  const source = useAppSelector((state) => (state as any).source);
-  const loadedSourceId = useAppSelector((state) => (state as any)?.source?.id);
-  const userAccessibleGroups = useAppSelector(
-    (state) => (state as any).groups.userAccessible,
-  );
+  // RTK Query: read results from the query hooks (no more redux slices).
+  const sources: any = fetchSourcesResult.data;
+  const source: any = getSourceResult.data;
+  const loadedSourceId = getSourceResult.data?.id;
+  const userAccessibleGroups = useGetGroupsQuery().data?.userAccessible ?? [];
   const userAccessibleGroupIds = useMemo(
     () => userAccessibleGroups?.map((a: any) => a.id),
     [userAccessibleGroups],

--- a/extensions/skyportal/static/js/components/alert/Alert.tsx
+++ b/extensions/skyportal/static/js/components/alert/Alert.tsx
@@ -39,7 +39,7 @@ import { ra_to_hours, dec_to_dms } from "../../units";
 
 import * as Actions from "../../ducks/boom_alert";
 import {
-  useLazyCheckSourceQuery,
+  useCheckSourceMutation,
   useLazyGetSourceQuery,
 } from "../../ducks/source";
 import { useLazyFetchSourcesQuery } from "../../ducks/sources";
@@ -498,7 +498,7 @@ const Alert = ({ route }: AlertProps) => {
   const [savedSource, setSavedSource] = useState(false);
   const [fetchedDuplicates, setFetchedDuplicates] = useState(false);
 
-  const [triggerCheckSource] = useLazyCheckSourceQuery();
+  const [triggerCheckSource] = useCheckSourceMutation();
   const [triggerGetSource, getSourceResult] = useLazyGetSourceQuery();
   const [triggerFetchSources, fetchSourcesResult] = useLazyFetchSourcesQuery();
 

--- a/extensions/skyportal/static/js/components/alert/Alerts.tsx
+++ b/extensions/skyportal/static/js/components/alert/Alerts.tsx
@@ -53,6 +53,7 @@ import { greatCircleDistance } from "../../utils";
 
 import * as alertActions from "../../ducks/boom_alert";
 import * as alertsActions from "../../ducks/boom_alerts";
+import { useGetGroupsQuery } from "../../ducks/groups";
 import { bytes2image } from "../../utils/imageProcessing";
 
 function isString(x: any) {
@@ -226,9 +227,8 @@ const Alerts = () => {
   const { alerts, queryInProgress } = useAppSelector(
     (state) => (state as any).alerts,
   );
-  const groups = useAppSelector(
-    (state) => (state as any).groups.userAccessible,
-  );
+  // RTK Query: groups come from the query hook (no more redux slice).
+  const groups = useGetGroupsQuery().data?.userAccessible ?? [];
 
   // save alerts to SP in bulk (by objectID)
   const [selectedSurvey, setSelectedSurvey] = useState("ZTF");

--- a/extensions/skyportal/static/js/components/alert/SaveAlertButton.tsx
+++ b/extensions/skyportal/static/js/components/alert/SaveAlertButton.tsx
@@ -22,7 +22,7 @@ import { useAppDispatch, useAppSelector } from "../../types/hooks";
 import FormValidationError from "../FormValidationError";
 
 import * as alertActions from "../../ducks/boom_alert";
-import * as sourceActions from "../../ducks/source";
+import { useLazyGetSourceQuery } from "../../ducks/source";
 
 interface SaveAlertButtonProps {
   alert: any;
@@ -34,6 +34,7 @@ const SaveAlertButton = ({ alert, userGroups }: SaveAlertButtonProps) => {
   // Dialog logic:
 
   const dispatch = useAppDispatch();
+  const [triggerGetSource] = useLazyGetSourceQuery();
   const [dialogOpen, setDialogOpen] = useState(false);
   const source = useAppSelector((state) => (state as any).source);
   const groups = (
@@ -107,7 +108,7 @@ const SaveAlertButton = ({ alert, userGroups }: SaveAlertButtonProps) => {
       setIsSubmitting(false);
       setDialogOpen(false);
       reset();
-      await dispatch(sourceActions.fetchSource(alert.id));
+      triggerGetSource(alert.id);
     }
   };
 

--- a/extensions/skyportal/static/js/components/alert/SaveAlertButton.tsx
+++ b/extensions/skyportal/static/js/components/alert/SaveAlertButton.tsx
@@ -17,12 +17,13 @@ import { useForm, Controller } from "react-hook-form";
 
 import { showNotification } from "baselayer/components/Notifications";
 
-import { useAppDispatch, useAppSelector } from "../../types/hooks";
+import { useAppDispatch } from "../../types/hooks";
 
 import FormValidationError from "../FormValidationError";
 
 import * as alertActions from "../../ducks/boom_alert";
 import { useLazyGetSourceQuery } from "../../ducks/source";
+import { useGetGroupsQuery } from "../../ducks/groups";
 
 interface SaveAlertButtonProps {
   alert: any;
@@ -34,12 +35,13 @@ const SaveAlertButton = ({ alert, userGroups }: SaveAlertButtonProps) => {
   // Dialog logic:
 
   const dispatch = useAppDispatch();
-  const [triggerGetSource] = useLazyGetSourceQuery();
+  const [triggerGetSource, getSourceResult] = useLazyGetSourceQuery();
   const [dialogOpen, setDialogOpen] = useState(false);
-  const source = useAppSelector((state) => (state as any).source);
-  const groups = (
-    useAppSelector((state) => (state as any).groups.all) || []
-  ).filter((g: any) => !g.single_user_group);
+  // RTK Query: read results from the query hooks (no more redux slices).
+  const source: any = getSourceResult.data;
+  const groups = (useGetGroupsQuery().data?.all ?? []).filter(
+    (g: any) => !g.single_user_group,
+  );
 
   const currentGroupIds =
     source?.id === alert.id


### PR DESCRIPTION
Builds on #588 (thomasculino:fix-test-frontend-boom) — branched from its current tip and layered the alert-component fix below, so it can be iterated to green independently.

## Why the boom frontend tests still fail on #588

skyportal's RTK Query migration (#6209) removed the `groups`, `source`, and `sources` redux slices. The alert components still read them via `useAppSelector((state) => state.groups.userAccessible / state.source / state.sources.latest)`, which now returns `undefined` → `TypeError` on render → the alerts **list and detail pages render blank**, so the boom frontend tests time out.

#588 converted the dispatchable thunks (`fetchSource`/`checkSource`/`fetchSources`) to lazy-query triggers, but left these **selectors** pointing at the removed slices. This reads them from the RTK Query hooks instead, matching skyportal's own migrated pattern:

- `groups` → `useGetGroupsQuery().data?.{userAccessible,all} ?? []`
- `source` → the `useLazyGetSourceQuery()` result's `.data`
- `sources` → the `useLazyFetchSourcesQuery()` result's `.data`

Files: `Alert.tsx`, `Alerts.tsx`, `SaveAlertButton.tsx`.

## Follow-ups (same root cause, not in the boom-test path, out of scope here)
`Archive.tsx` (removed `checkSource` thunk + `state.groups`), the filter plugins (`state.groups`/`state.profile`), and `CopyAlertPhotometryDialog` (`state.groups`) read the same removed slices and will need the same treatment.