### PR TITLE
Parse numbers inside $in operator

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -138,6 +138,15 @@ jobs:
               environment:
                 BOOM_API__AUTH__SECRET_KEY: ${BOOM_API__AUTH__SECRET_KEY}
                 BOOM_API__AUTH__ADMIN_PASSWORD: ${BOOM_API__AUTH__ADMIN_PASSWORD}
+            consumer-winter:
+              environment:
+                BOOM_API__AUTH__SECRET_KEY: ${BOOM_API__AUTH__SECRET_KEY}
+                BOOM_API__AUTH__ADMIN_PASSWORD: ${BOOM_API__AUTH__ADMIN_PASSWORD}
+                BOOM_KAFKA__CONSUMER__WINTER__SERVER: broker:29092
+            scheduler-winter:
+              environment:
+                BOOM_API__AUTH__SECRET_KEY: ${BOOM_API__AUTH__SECRET_KEY}
+                BOOM_API__AUTH__ADMIN_PASSWORD: ${BOOM_API__AUTH__ADMIN_PASSWORD}
           EOF
 
       - name: Bring up boom stack
@@ -173,6 +182,7 @@ jobs:
           # if our filter matches every seeded alert.
           BOOM_WORKERS__ZTF__FILTER__MAX_MATCH_RATE: "100"
           BOOM_KAFKA__CONSUMER__WINTER__GROUP_ID: boom-winter-consumer-group
+          BOOM_KAFKA__CONSUMER__WINTER__SERVER: broker:29092
         run: |
           docker compose -p boom \
             -f docker-compose.yaml \

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -172,6 +172,7 @@ jobs:
           # Allow up to 100% match rate so the validation test passes even
           # if our filter matches every seeded alert.
           BOOM_WORKERS__ZTF__FILTER__MAX_MATCH_RATE: "100"
+          BOOM_KAFKA__CONSUMER__WINTER__GROUP_ID: boom-winter-consumer-group
         run: |
           docker compose -p boom \
             -f docker-compose.yaml \

--- a/extensions/skyportal/static/js/utils/mongoPipelineBuilder.js
+++ b/extensions/skyportal/static/js/utils/mongoPipelineBuilder.js
@@ -3380,15 +3380,16 @@ const convertSchemaFieldCondition = (
       return { [field]: { $lt: processedValue } };
     case "$lte":
       return { [field]: { $lte: processedValue } };
-    case "$in":
-      // For $in, ensure processedValue is an array
+    case "$in": {
+      const inArray = Array.isArray(processedValue)
+        ? processedValue
+        : [processedValue];
       return {
         [field]: {
-          $in: Array.isArray(processedValue)
-            ? processedValue
-            : [processedValue],
+          $in: inArray.map(parseNumberIfNeeded),
         },
       };
+    }
     case "$lengthGt":
     case "length >":
       return { $expr: { $gt: [{ $size: `$${field}` }, processedValue] } };


### PR DESCRIPTION
The $in operator was always parsing values to string which was a blocker for non string values such as fields.