### PR TITLE
alert page: read unwrapped source_exists

### DIFF
--- a/extensions/skyportal/skyportal/tests/frontend/boom/test_boom_alerts_frontend.py
+++ b/extensions/skyportal/skyportal/tests/frontend/boom/test_boom_alerts_frontend.py
@@ -167,3 +167,34 @@ def test_save_alert_as_source(page, boom_seed_oid, public_group, super_admin_tok
         f"Source {boom_seed_oid} never appeared after submit "
         f"(last GET /sources status={last_status})"
     )
+
+
+@pytest.mark.requires_boom_data
+def test_saved_alert_shows_group_chips(
+    page, boom_seed_oid, public_group, super_admin_token
+):
+    """Regression: once saved, the alert detail page must render the source's
+    group chips (the "saved" state), not "NOT SAVED".
+
+    The saved check reads GET /api/source_exists, whose {status, data, version}
+    envelope skyportalBaseQuery strips — so Alert.tsx must read
+    ``result.data.source_exists`` directly. It previously tested the pre-unwrap
+    shape (``result.data.status``/``result.data.data.source_exists``), which is
+    always undefined, so every alert rendered "NOT SAVED" with no group chips.
+    """
+    # Save the object as a Source up front (the UI save flow itself is covered
+    # by test_save_alert_as_source); we only need the saved state on page load.
+    status, _ = api(
+        "POST",
+        f"boom/surveys/ZTF/objects/{boom_seed_oid}",
+        data={"group_ids": [public_group.id]},
+        token=super_admin_token,
+    )
+    assert status == 200
+
+    page.goto(f"/alerts/ZTF/{boom_seed_oid}")
+    # The saved branch renders one chip per group (data-testid=groupChip_<id>);
+    # the bug always fell through to a bare "NOT SAVED" chip instead.
+    expect(
+        page.locator(f"//*[@data-testid='groupChip_{public_group.id}']").first
+    ).to_be_visible(timeout=30000)

--- a/extensions/skyportal/skyportal/tests/frontend/boom/test_boom_alerts_frontend.py
+++ b/extensions/skyportal/skyportal/tests/frontend/boom/test_boom_alerts_frontend.py
@@ -155,46 +155,30 @@ def test_save_alert_as_source(page, boom_seed_oid, public_group, super_admin_tok
     # → Obj + Source created.
     deadline = time.time() + 30
     last_status = None
+    saved = False
     while time.time() < deadline:
         last_status, data = api(
             "GET", f"sources/{boom_seed_oid}", token=super_admin_token
         )
         if last_status == 200 and data.get("status") == "success":
             assert data["data"]["id"] == boom_seed_oid
-            return
+            saved = True
+            break
         time.sleep(1)
-    pytest.fail(
-        f"Source {boom_seed_oid} never appeared after submit "
-        f"(last GET /sources status={last_status})"
-    )
+    if not saved:
+        pytest.fail(
+            f"Source {boom_seed_oid} never appeared after submit "
+            f"(last GET /sources status={last_status})"
+        )
 
-
-@pytest.mark.requires_boom_data
-def test_saved_alert_shows_group_chips(
-    page, boom_seed_oid, public_group, super_admin_token
-):
-    """Regression: once saved, the alert detail page must render the source's
-    group chips (the "saved" state), not "NOT SAVED".
-
-    The saved check reads GET /api/source_exists, whose {status, data, version}
-    envelope skyportalBaseQuery strips — so Alert.tsx must read
-    ``result.data.source_exists`` directly. It previously tested the pre-unwrap
-    shape (``result.data.status``/``result.data.data.source_exists``), which is
-    always undefined, so every alert rendered "NOT SAVED" with no group chips.
-    """
-    # Save the object as a Source up front (the UI save flow itself is covered
-    # by test_save_alert_as_source); we only need the saved state on page load.
-    status, _ = api(
-        "POST",
-        f"boom/surveys/ZTF/objects/{boom_seed_oid}",
-        data={"group_ids": [public_group.id]},
-        token=super_admin_token,
-    )
-    assert status == 200
-
+    # Regression for the alert saved-state: re-open the detail page (as the same
+    # user who just saved it, so the Source is visible) and confirm it renders a
+    # chip per group (data-testid=groupChip_<id>) rather than "NOT SAVED". The
+    # check reads GET /api/source_exists, whose {status, data, version} envelope
+    # skyportalBaseQuery strips — Alert.tsx must read result.data.source_exists
+    # directly; it previously read the pre-unwrap shape and always fell through
+    # to "NOT SAVED".
     page.goto(f"/alerts/ZTF/{boom_seed_oid}")
-    # The saved branch renders one chip per group (data-testid=groupChip_<id>);
-    # the bug always fell through to a bare "NOT SAVED" chip instead.
     expect(
         page.locator(f"//*[@data-testid='groupChip_{public_group.id}']").first
     ).to_be_visible(timeout=30000)

--- a/extensions/skyportal/skyportal/tests/frontend/boom/test_boom_alerts_frontend.py
+++ b/extensions/skyportal/skyportal/tests/frontend/boom/test_boom_alerts_frontend.py
@@ -172,13 +172,15 @@ def test_save_alert_as_source(page, boom_seed_oid, public_group, super_admin_tok
         )
 
     # Regression for the alert saved-state: re-open the detail page (as the same
-    # user who just saved it, so the Source is visible) and confirm it renders a
-    # chip per group (data-testid=groupChip_<id>) rather than "NOT SAVED". The
-    # check reads GET /api/source_exists, whose {status, data, version} envelope
-    # skyportalBaseQuery strips — Alert.tsx must read result.data.source_exists
-    # directly; it previously read the pre-unwrap shape and always fell through
-    # to "NOT SAVED".
+    # user who just saved it, so the Source is visible) and confirm it renders
+    # the saved branch ("Previously Saved") instead of "NOT SAVED". That branch
+    # is gated on the GET /api/source_exists check, whose {status, data, version}
+    # envelope skyportalBaseQuery strips — Alert.tsx must read
+    # result.data.source_exists directly; it previously read the pre-unwrap shape
+    # and always fell through to "NOT SAVED". Asserted on the branch's own chip
+    # rather than the per-group chips, which need the lazy getSource to have
+    # resolved with groups too.
     page.goto(f"/alerts/ZTF/{boom_seed_oid}")
     expect(
-        page.locator(f"//*[@data-testid='groupChip_{public_group.id}']").first
+        page.locator("//*[contains(text(),'Previously Saved')]").first
     ).to_be_visible(timeout=30000)

--- a/extensions/skyportal/static/js/components/alert/Alert.tsx
+++ b/extensions/skyportal/static/js/components/alert/Alert.tsx
@@ -560,10 +560,10 @@ const Alert = ({ route }: AlertProps) => {
         id: objectId,
         params: { nameOnly: true },
       });
-      if (
-        result.data?.status === "success" &&
-        result.data?.data?.source_exists === true
-      ) {
+      // skyportalBaseQuery already unwraps the {status, data, version} envelope,
+      // so result.data is the payload itself (see ExecutedObservationsTable /
+      // NewSource, which use the same shape).
+      if (result.data?.source_exists === true) {
         setSavedSource(true);
         triggerGetSource(objectId);
       } else {


### PR DESCRIPTION
This PR ensures the alert page reads unwrapped source_exists.