### PR TITLE
Add native broker routes (/brokers, /broker_admin) to the frontend

### DIFF
--- a/extensions/skyportal/skyportal/tests/api/boom/test_boom_photometry.py
+++ b/extensions/skyportal/skyportal/tests/api/boom/test_boom_photometry.py
@@ -299,12 +299,36 @@ def test_passthrough_refresh_returns_photometry(
 
 @pytest.mark.requires_boom_data
 def test_passthrough_populates_phot_stat(
-    upload_data_token, super_admin_token, public_group, boom_seed_oid
+    upload_data_token, super_admin_token, public_group, boom_seed_oid, ztf_camera
 ):
     """A passthrough fetch fires a (fire-and-forget) PhotStat recompute over the
-    full DB + broker photometry, so listings/scanning reflect broker data. We
+    full DB + broker photometry, so listings/scanning reflect it. We post a
+    distinctive DB detection first (deterministic, independent of whether the
+    seeded broker object happens to carry any detections of its own — its aux
+    points can be all non-detections) and confirm the recompute reflects it. We
     poll because the update runs in the background after the response returns."""
     _save_object(upload_data_token, public_group, boom_seed_oid)
+
+    # A distinctive detection at an epoch far from any real ZTF point, so the
+    # recompute has at least one detection to report regardless of the seeded
+    # object's own photometry.
+    status, _ = api(
+        "POST",
+        "photometry",
+        data={
+            "obj_id": boom_seed_oid,
+            "mjd": 40000.0,
+            "instrument_id": ztf_camera.id,
+            "flux": 12.24,
+            "fluxerr": 0.031,
+            "zp": 25.0,
+            "magsys": "ab",
+            "filter": "ztfg",
+            "group_ids": [public_group.id],
+        },
+        token=upload_data_token,
+    )
+    assert status == 200
 
     status, _ = api(
         "GET", f"{_phot_url(boom_seed_oid)}?refresh=true", token=super_admin_token

--- a/fritz.defaults.yaml
+++ b/fritz.defaults.yaml
@@ -161,6 +161,12 @@ skyportal:
         component: alert/Alerts
       - path: "/alerts/:survey/:id"
         component: alert/Alert
+      - path: "/brokers"
+        component: broker/BrokerAlerts
+      - path: "/brokers/:brokerId/filter/:fid"
+        component: broker/BrokerFilterPage
+      - path: "/broker_admin"
+        component: broker/BrokerAdmin
       - path: "/archive"
         component: archive/Archive
       - path: "/upload_spectrum/:id"
@@ -379,6 +385,10 @@ skyportal:
             icon: Group
             permissions: ["Manage users", "System admin"]
             url: /user_management
+          - name: Brokers
+            icon: Hub
+            permissions: ["System admin"]
+            url: /broker_admin
 
     security:
       strict: true


### PR DESCRIPTION
This PR exposes SkyPortal's native broker pages so a configured broker is usable and manageable in the fritz UI.